### PR TITLE
Fixed fileset-hashing

### DIFF
--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -80,7 +80,7 @@ class FileSet(DataType):
     is_fileset = True
 
     def __hash__(self):
-        return hash(sorted(self.fspaths))
+        return hash(self.fspaths)
 
     def __repr__(self):
         return (

--- a/fileformats/core/tests/test_general.py
+++ b/fileformats/core/tests/test_general.py
@@ -1,5 +1,7 @@
+from pathlib import Path
 import pytest
 from fileformats.generic import File
+from fileformats.field import Integer, Boolean, Decimal, Array, Text
 from fileformats.core.exceptions import FileFormatsError, FormatMismatchError
 from fileformats.core import mark
 from conftest import write_test_file
@@ -49,6 +51,70 @@ def test_missing_files(work_dir):
     write_test_file(fspath)
     with pytest.raises(FileNotFoundError):
         TestFile([fspath, work_dir / "missing1.txt", work_dir / "missing2.txt"])
+
+
+def test_python_hash_fileset(work_dir: Path):
+
+    a_path = work_dir / "a.txt"
+    a_path.write_text("a")
+    a = File(a_path)
+    a2 = File(a_path)
+    b_path = work_dir / "b.txt"
+    b_path.write_text("b")
+    b = File(b_path)
+
+    assert hash(a) == hash(a2)
+    assert hash(b) != hash(a)
+
+
+def test_python_hash_integer():
+
+    a = Integer(1)
+    a2 = Integer(1)
+    b = Integer(2)
+
+    assert hash(a) == hash(a2)
+    assert hash(b) != hash(a)
+
+
+def test_python_hash_decimal():
+
+    a = Decimal(1)
+    a2 = Decimal(1)
+    b = Decimal(2)
+
+    assert hash(a) == hash(a2)
+    assert hash(b) != hash(a)
+
+
+def test_python_hash_boolean():
+
+    a = Boolean(1)
+    a2 = Boolean(1)
+    b = Boolean(0)
+
+    assert hash(a) == hash(a2)
+    assert hash(b) != hash(a)
+
+
+def test_python_hash_text():
+
+    a = Text("1")
+    a2 = Text("1")
+    b = Text("2")
+
+    assert hash(a) == hash(a2)
+    assert hash(b) != hash(a)
+
+
+def test_python_hash_array():
+
+    a = Array[Integer]([1, 2])
+    a2 = Array[Integer]([1, 2])
+    b = Array[Integer]([1, 2, 3])
+
+    assert hash(a) == hash(a2)
+    assert hash(b) != hash(a)
 
 
 class ImageWithInlineHeader(File):

--- a/fileformats/core/tests/test_general.py
+++ b/fileformats/core/tests/test_general.py
@@ -15,14 +15,6 @@ def test_init_args(work_dir):
         File(fspath, fspath)
 
 
-# def test_metadata_iterator_fail(work_dir):
-#     fspath = work_dir / "test.txt"
-#     write_test_file(fspath)
-#     file = File(fspath)
-#     with pytest.raises(NotImplementedError):
-#         iter(file.metadata)
-
-
 class TestFile(File):
 
     ext = ".tst"

--- a/fileformats/generic/__init__.py
+++ b/fileformats/generic/__init__.py
@@ -8,7 +8,6 @@ from fileformats.core.utils import classproperty
 from fileformats.core.mixin import WithClassifiers
 
 
-@attrs.define
 class FsObject(FileSet, os.PathLike):
     "Generic file-system object, can be either a file or a directory"
 
@@ -35,7 +34,6 @@ class FsObject(FileSet, os.PathLike):
         return self.fspath.with_suffix("").name
 
 
-@attrs.define
 class File(FsObject):
     """Generic file type"""
 
@@ -142,7 +140,6 @@ class File(FsObject):
         return stem
 
 
-@attrs.define
 class Directory(FsObject):
     """Base directory to be overridden by subtypes that represent directories but don't
     want to inherit content type "qualifers" (i.e. most of them)"""


### PR DESCRIPTION
* Fixes Python fileset hashing (i.e. makes FileSet's hashable via `hash()`, not to be confused with file-contents hashing), which wasn't being inherited by child classes.
* Ensures all datatypes (including fields) can be hashed