### PR TITLE
List and Union mime-like representations

### DIFF
--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -19,22 +19,13 @@ For example, the `FileFormats Medimage Extension <https://github.com/ArcanaFrame
 implements a range of file formats used in medical imaging research under the
 ``fileformats.medimage`` namespace.
 
-When designing an extension packages, try to keep any external dependencies to a bare
-minimum in the base installation, and add them into the ``[extended]`` optional
-dependencies. When importing extended dependencies in a module, enclose them in
-a try-except statement that catches ImportErrors and sets the module to a
-``MissingExtendedDependency`` instead, e.g.
+When designing an extension packages, try to keep any external dependencies to an absolute
+minimum (ideally just `attrs`). If you would like to implement extra functionality into
+your format classes in addition to the core detection/validation, please use an "extra"
+hook and implement the method in an "extras" package (i.e. fileformats-<yournamespace>-extras),
+see the `extras template <https://github.com/ArcanaFramework/fileformats-extras-template>`__
+for further instructions.
 
-.. code-block:: python
-
-    from fileformats.core import MissingExtendedDependency
-    try:
-        import external_package
-    except ImportError:
-        external_package = MissingExtendedDependency("external_package", __name__)
-
-This will raise an informative error message, if a user attempts to access this the
-external package.
 
 Basic formats
 -------------
@@ -277,7 +268,11 @@ Converters between two equivalent formats are defined using Pydra_ dataflow engi
 of Pydra_ tasks, function tasks, Python functions decorated by ``@pydra.mark.task``, and
 shell-command tasks, which wrap command-line tools in Python classes. To register a
 Pydra_ task as a converter between two file formats it needs to be decorated with the
-``@fileformats.core.mark.converter`` decorator.
+``@fileformats.core.mark.converter`` decorator. Note that converters that rely on
+any additional dependencies should not be implemented in your extension package, rather
+in a sister "extras" package named `fileformats-<yournamespace>-extras`,
+see the `extras template <https://github.com/ArcanaFramework/fileformats-extras-template>`__
+for further instructions.
 
 Pydra uses type annotations to define the input and outputs of the tasks. It there is
 a input to the task named ``in_file``, and either a single anonymous output or an output

--- a/fileformats/core/__init__.py
+++ b/fileformats/core/__init__.py
@@ -3,7 +3,7 @@ from .datatype import DataType
 from .fileset import FileSet
 from .field import Field
 from .utils import (
+    to_mime,
     from_mime,
     find_matching,
-    MissingExtendedDependency,
 )

--- a/fileformats/core/exceptions.py
+++ b/fileformats/core/exceptions.py
@@ -14,10 +14,6 @@ class FormatRecognitionError(KeyError, FileFormatsError):
     "Did not find a format class corresponding to a MIME, or MIME-like, type string"
 
 
-class MissingExtendedDepenciesError(FileFormatsError):
-    "'extended' install extra wasn't installed required for advanced behaviour"
-
-
 class FileFormatsExtrasError(FileFormatsError):
     """If there is an "extras hook" in the datatype class but no methods have been
     registered on it"""

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -921,6 +921,8 @@ class FileSet(DataType):
     def decompose_fspath(
         cls, fspath: Path, mode: ExtensionDecomposition = ExtensionDecomposition.single
     ) -> ty.Tuple[Path, str, str]:
+        if isinstance(fspath, str):
+            fspath = Path(fspath)
         """Decompose an arbitrary file-system path into parent dir, stem and extension
         given the assumption on what constitutes an extension"""
         if mode == cls.ExtensionDecomposition.multiple:

--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -14,7 +14,7 @@ from fileformats.core.utils import (
     from_mime,
 )
 from fileformats.core.exceptions import FileFormatsError
-from fileformats.testing import Foo
+from fileformats.testing import Foo, Bar
 import fileformats.text
 from conftest import write_test_file
 
@@ -399,6 +399,11 @@ def test_to_from_list_mime_roundtrip():
     assert from_mime(mime_str) == ty.List[Foo]
 
 
-def test_list_iana_mime_fail():
-    with pytest.raises(TypeError, match="to official mime-type as it is a list"):
-        to_mime(ty.List[Foo], iana=True)
+def test_to_from_union_mime_roundtrip():
+    mime_str = to_mime(ty.Union[Foo, Bar])
+    assert from_mime(mime_str) == ty.Union[Foo, Bar]
+
+
+def test_official_mime_fail():
+    with pytest.raises(TypeError, match="as it is not a proper file-type"):
+        to_mime(ty.List[Foo], official=True)

--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -404,6 +404,11 @@ def test_to_from_union_mime_roundtrip():
     assert from_mime(mime_str) == ty.Union[Foo, Bar]
 
 
+def test_to_from_list_union_mime_roundtrip():
+    mime_str = to_mime(ty.List[ty.Union[Foo, Bar]])
+    assert from_mime(mime_str) == ty.List[ty.Union[Foo, Bar]]
+
+
 def test_official_mime_fail():
     with pytest.raises(TypeError, match="as it is not a proper file-type"):
         to_mime(ty.List[Foo], official=True)

--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -391,21 +391,25 @@ def test_hash_files(fsobject: FsObject, work_dir: Path, dest_dir: Path):
 
 def test_to_from_mime_roundtrip():
     mime_str = to_mime(Foo)
+    assert isinstance(mime_str, str)
     assert from_mime(mime_str) == Foo
 
 
 def test_to_from_list_mime_roundtrip():
     mime_str = to_mime(ty.List[Foo])
+    assert isinstance(mime_str, str)
     assert from_mime(mime_str) == ty.List[Foo]
 
 
 def test_to_from_union_mime_roundtrip():
     mime_str = to_mime(ty.Union[Foo, Bar])
+    assert isinstance(mime_str, str)
     assert from_mime(mime_str) == ty.Union[Foo, Bar]
 
 
 def test_to_from_list_union_mime_roundtrip():
     mime_str = to_mime(ty.List[ty.Union[Foo, Bar]])
+    assert isinstance(mime_str, str)
     assert from_mime(mime_str) == ty.List[ty.Union[Foo, Bar]]
 
 

--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -297,7 +297,7 @@ def test_format_detection(work_dir):
     assert sorted(detected, key=lambda f: f.mime_like) == [
         fileformats.text.Prs_Fallenstein_Rst,
         fileformats.text.Prs_Prop_Logic,
-        fileformats.text.TxtFile,
+        fileformats.text.TextFile,
     ]
 
 

--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -9,9 +9,8 @@ from fileformats.generic import File, Directory, FsObject
 from fileformats.core.mixin import WithSeparateHeader
 from fileformats.core.utils import (
     find_matching,
-    MissingExtendedDependency,
 )
-from fileformats.core.exceptions import MissingExtendedDepenciesError, FileFormatsError
+from fileformats.core.exceptions import FileFormatsError
 import fileformats.text
 from conftest import write_test_file
 
@@ -293,13 +292,6 @@ def test_format_detection(work_dir):
         fileformats.text.Prs_Prop_Logic,
         fileformats.text.Txt,
     ]
-
-
-def test_missing_dependency():
-    missing_dep = MissingExtendedDependency("missing_dep", "fileformats.image")
-
-    with pytest.raises(MissingExtendedDepenciesError):
-        missing_dep.an_attr
 
 
 def test_hash(tmp_path: Path):

--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import os.path
 import random
 import shutil
+import typing as ty
 import time
 import pytest
 from fileformats.core import FileSet, mark
@@ -9,50 +10,53 @@ from fileformats.generic import File, Directory, FsObject
 from fileformats.core.mixin import WithSeparateHeader
 from fileformats.core.utils import (
     find_matching,
+    to_mime,
+    from_mime,
 )
 from fileformats.core.exceptions import FileFormatsError
+from fileformats.testing import Foo
 import fileformats.text
 from conftest import write_test_file
 
 
-class Bar(File):
-    ext = ".bar"
+class Mario(File):
+    ext = ".mario"
 
 
-class Foo(WithSeparateHeader, File):
-    ext = ".foo"
-    header_type = Bar
+class Luigi(WithSeparateHeader, File):
+    ext = ".luigi"
+    header_type = Mario
 
 
-class Baz(Directory):
-    content_types = (Bar,)
+class Bowser(Directory):
+    content_types = (Mario,)
 
 
 @pytest.fixture
-def baz_dir(work_dir):
-    baz_dir = work_dir / "baz"
-    baz_dir.mkdir()
+def bowser_dir(work_dir):
+    bowser_dir = work_dir / "bowser"
+    bowser_dir.mkdir()
     for i in range(5):
-        bar_fspath = baz_dir / f"{i}.bar"
+        bar_fspath = bowser_dir / f"{i}.mario"
         write_test_file(bar_fspath)
-    return Baz(baz_dir)
+    return Bowser(bowser_dir)
 
 
 @pytest.fixture
-def foo_file(work_dir):
-    foo_fspath = work_dir / "x.foo"
-    write_test_file(foo_fspath)
-    bar_fspath = work_dir / "y.bar"
+def luigi_file(work_dir):
+    luigi_fspath = work_dir / "x.luigi"
+    write_test_file(luigi_fspath)
+    bar_fspath = work_dir / "y.mario"
     write_test_file(bar_fspath)
-    return Foo([foo_fspath, bar_fspath])
+    return Luigi([luigi_fspath, bar_fspath])
 
 
-@pytest.fixture(params=["foo", "baz"])
-def fsobject(foo_file, baz_dir, request):
-    if request.param == "foo":
-        return foo_file
-    elif request.param == "baz":
-        return baz_dir
+@pytest.fixture(params=["luigi", "bowser"])
+def fsobject(luigi_file, bowser_dir, request):
+    if request.param == "luigi":
+        return luigi_file
+    elif request.param == "bowser":
+        return bowser_dir
     else:
         assert False
 
@@ -195,11 +199,11 @@ def test_copy_collation_stem(work_dir: Path, dest_dir: Path):
     assert all(p.stem == "newfile" for p in cpy.fspaths)
 
 
-def test_copy_collation_with_stem_not_adjacent(foo_file: Foo, dest_dir):
+def test_copy_collation_with_stem_not_adjacent(luigi_file: Luigi, dest_dir):
     with pytest.raises(
         FileFormatsError, match="when collation is not set to 'adjacent'"
     ):
-        foo_file.copy(dest_dir, collation="any", new_stem="new")
+        luigi_file.copy(dest_dir, collation="any", new_stem="new")
 
 
 def test_copy_collation_leave_diff_dir(work_dir: Path, dest_dir: Path):
@@ -230,7 +234,7 @@ def test_copy_collation_leave_diff_dir(work_dir: Path, dest_dir: Path):
 def test_copy_ext(work_dir):
     assert (
         File.copy_ext(
-            work_dir / "x.foo.bar",
+            work_dir / "x.luigi.mario",
             work_dir / "y",
             decomposition_mode=FileSet.ExtensionDecomposition.none,
         )
@@ -238,46 +242,49 @@ def test_copy_ext(work_dir):
     )
     assert (
         File.copy_ext(
-            work_dir / "x.foo.bar",
+            work_dir / "x.luigi.mario",
             work_dir / "y",
             decomposition_mode=FileSet.ExtensionDecomposition.single,
         )
-        == work_dir / "y.bar"
+        == work_dir / "y.mario"
     )
     assert (
         File.copy_ext(
-            work_dir / "x.foo.bar",
+            work_dir / "x.luigi.mario",
             work_dir / "y",
             decomposition_mode=FileSet.ExtensionDecomposition.multiple,
         )
-        == work_dir / "y.foo.bar"
+        == work_dir / "y.luigi.mario"
     )
-    assert Bar.copy_ext(work_dir / "x.foo.bar", work_dir / "y") == work_dir / "y.bar"
+    assert (
+        Mario.copy_ext(work_dir / "x.luigi.mario", work_dir / "y")
+        == work_dir / "y.mario"
+    )
 
 
 def test_decompose_fspaths(work_dir):
-    class FooBar(File):
-        ext = ".foo.bar"
+    class LuigiMario(File):
+        ext = ".luigi.mario"
 
-    class DoubleBar(FileSet):
+    class DoubleMario(FileSet):
         @mark.required
         @property
         def bar(self):
-            return Bar(self.select_by_ext(Bar))
+            return Mario(self.select_by_ext(Mario))
 
         @mark.required
         @property
-        def foo_bar(self):
-            return FooBar(self.select_by_ext(FooBar))
+        def luigi_bar(self):
+            return LuigiMario(self.select_by_ext(LuigiMario))
 
-    fspath = work_dir / "file.foo.bar"
+    fspath = work_dir / "file.luigi.mario"
     Path.touch(fspath)
-    double_bar = DoubleBar(fspath)
+    double_bar = DoubleMario(fspath)
 
     with pytest.warns(match="whereas it is also interpreted as a"):
         decomposed = double_bar.decomposed_fspaths()
 
-    assert decomposed == [(work_dir, "file.foo", ".bar")]
+    assert decomposed == [(work_dir, "file.luigi", ".mario")]
 
 
 def test_format_detection(work_dir):
@@ -290,7 +297,7 @@ def test_format_detection(work_dir):
     assert sorted(detected, key=lambda f: f.mime_like) == [
         fileformats.text.Prs_Fallenstein_Rst,
         fileformats.text.Prs_Prop_Logic,
-        fileformats.text.Txt,
+        fileformats.text.TxtFile,
     ]
 
 
@@ -313,7 +320,7 @@ def test_hash_function_files_mismatch(tmp_path: Path):
 
 
 def test_hash_dir(tmp_path: Path):
-    dir1 = tmp_path / "foo"
+    dir1 = tmp_path / "luigi"
     dir2 = tmp_path / "bar"
     for d in (dir1, dir2):
         d.mkdir()
@@ -380,3 +387,18 @@ def test_hash_files(fsobject: FsObject, work_dir: Path, dest_dir: Path):
     )
     cpy = fsobject.copy(dest_dir)
     assert cpy.hash_files() == fsobject.hash_files()
+
+
+def test_to_from_mime_roundtrip():
+    mime_str = to_mime(Foo)
+    assert from_mime(mime_str) == Foo
+
+
+def test_to_from_list_mime_roundtrip():
+    mime_str = to_mime(ty.List[Foo])
+    assert from_mime(mime_str) == ty.List[Foo]
+
+
+def test_list_iana_mime_fail():
+    with pytest.raises(TypeError, match="to official mime-type as it is a list"):
+        to_mime(ty.List[Foo], iana=True)

--- a/fileformats/core/utils.py
+++ b/fileformats/core/utils.py
@@ -118,7 +118,7 @@ def to_mime(datatype: type, iana=False):
     if ty.get_origin(datatype) is list:
         dtype = ty.get_args(datatype)[0]
         if iana:
-            raise ValueError(
+            raise TypeError(
                 f"Cannot convert {datatype} to official mime-type as it is a list, "
                 'please use iana=False to convert to "mime-like" string instead'
             )

--- a/fileformats/core/utils.py
+++ b/fileformats/core/utils.py
@@ -11,7 +11,6 @@ import logging
 import pkgutil
 from contextlib import contextmanager
 from fileformats.core.exceptions import (
-    MissingExtendedDepenciesError,
     FileFormatsError,
 )
 import fileformats.core
@@ -191,37 +190,6 @@ class classproperty(object):
 
     def __get__(self, obj, owner):
         return self.f(owner)
-
-
-class MissingExtendedDependency:
-    """Used as a placeholder for package dependencies that are only installed with the
-    "extended" install extra.
-
-    Parameters
-    ----------
-    pkg_name : str
-        name of the package to act as a placeholder for
-    module_path : str
-        path of the module, i.e. the value of the '__name__' global variable
-    """
-
-    def __init__(self, pkg_name: str, module_path: str):
-        self.pkg_name = pkg_name
-        module_parts = module_path.split(".")
-        assert module_parts[0] == "fileformats"
-        if module_parts[1] in STANDARD_NAMESPACES:
-            self.required_in = "fileformats"
-        else:
-            self.required_in = f"fileformats-{module_parts[1]}"
-
-    def __getattr__(self, _):
-        raise MissingExtendedDepenciesError(
-            f"Not able to access extended behaviour in {self.required_in} as required "
-            f"package '{self.pkg_name}' was not installed. Please reinstall "
-            f"{self.required_in} with 'extended' install extra to access extended "
-            f"behaviour of the format classes (such as loading and conversion), i.e.\n\n"
-            f"    $ python3 -m pip install {self.required_in}[extended]"
-        )
 
 
 STANDARD_NAMESPACES = [

--- a/fileformats/serialization/__init__.py
+++ b/fileformats/serialization/__init__.py
@@ -4,7 +4,6 @@ from ..core import __version__, mark, DataType
 from ..core.mixin import WithClassifiers
 from ..generic import File
 from ..core.exceptions import FormatMismatchError
-from ..core.utils import MissingExtendedDependency
 
 
 class Schema(DataType):

--- a/fileformats/text/__init__.py
+++ b/fileformats/text/__init__.py
@@ -18,7 +18,7 @@ class Plain(Text):
     iana_mime = "text/plain"
 
 
-class TxtFile(Text):
+class TextFile(Text):
     ext = ".txt"
 
 

--- a/fileformats/text/__init__.py
+++ b/fileformats/text/__init__.py
@@ -18,7 +18,7 @@ class Plain(Text):
     iana_mime = "text/plain"
 
 
-class Txt(Text):
+class TxtFile(Text):
     ext = ".txt"
 
 


### PR DESCRIPTION
* adds the ability to convert lists and unions of fileformat types to mime-like strings
* Removes the MissingDependency exception handling (dependencies should be referenced in *-extras packages)
* Renames fileformats.text.Txt to fileformats.text.TextFile
* Updates docs to remove references to extended dependencies