### PR TITLE
Minor additions + bug-fixes to get Pydra/Arcana tests to pass

### DIFF
--- a/fileformats/core/exceptions.py
+++ b/fileformats/core/exceptions.py
@@ -14,6 +14,10 @@ class FormatRecognitionError(KeyError, FileFormatsError):
     "Did not find a format class corresponding to a MIME, or MIME-like, type string"
 
 
+class UnconstrainedExtensionException(FileFormatsError):
+    "Did not find a format class corresponding to a MIME, or MIME-like, type string"
+
+
 class FileFormatsExtrasError(FileFormatsError):
     """If there is an "extras hook" in the datatype class but no methods have been
     registered on it"""

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -1243,3 +1243,6 @@ class MockMixin:
     def _type_name(cls):
         assert cls.__name__.endswith("Mock")
         return cls.__name__[: -len("Mock")]
+
+    def __bytes_repr__(self, cache):
+        yield from (str(fspath).encode() for fspath in self.fspaths)

--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -199,13 +199,6 @@ def test_copy_collation_stem(work_dir: Path, dest_dir: Path):
     assert all(p.stem == "newfile" for p in cpy.fspaths)
 
 
-def test_copy_collation_with_stem_not_adjacent(luigi_file: Luigi, dest_dir):
-    with pytest.raises(
-        FileFormatsError, match="when collation is not set to 'adjacent'"
-    ):
-        luigi_file.copy(dest_dir, collation="any", new_stem="new")
-
-
 def test_copy_collation_leave_diff_dir(work_dir: Path, dest_dir: Path):
     a = work_dir / "a" / "file.x"
     b = work_dir / "b" / "file.y"

--- a/fileformats/field/__init__.py
+++ b/fileformats/field/__init__.py
@@ -113,9 +113,16 @@ def boolean_converter(value):
 
 def array_converter(value):
     if isinstance(value, str):
-        if value.startswith("[") and value.endswith("]"):
+        if (value.startswith("[") and value.endswith("]")) or (
+            value.startswith("(") and value.endswith(")")
+        ):
             value = value[1:-1]
-        elif value.startswith("[") or value.endswith("]"):
+        elif (
+            value.startswith("[")
+            or value.endswith("]")
+            or value.startswith("(")
+            or value.endswith(")")
+        ):
             raise FormatMismatchError(f"Unmatched brackets in array field {value}")
         value = tuple(v.strip() for v in value.split(","))
     else:
@@ -128,7 +135,6 @@ def array_converter(value):
 
 @attrs.define(repr=False)
 class Text(Singular):
-
     value: str = attrs.field(converter=text_converter)
 
     primitive = str
@@ -142,7 +148,6 @@ class Text(Singular):
 
 @attrs.define(repr=False)
 class Integer(Singular, ScalarMixin):
-
     value: int = attrs.field(converter=integer_converter)
 
     primitive = int
@@ -162,7 +167,6 @@ class Integer(Singular, ScalarMixin):
 
 @attrs.define(repr=False)
 class Decimal(Singular, ScalarMixin):
-
     value: decimal.Decimal = attrs.field(converter=decimal_converter)
 
     primitive = float
@@ -179,7 +183,6 @@ class Decimal(Singular, ScalarMixin):
 
 @attrs.define(repr=False)
 class Boolean(Singular, LogicalMixin):
-
     primitive = bool
 
     value: bool = attrs.field(converter=boolean_converter)
@@ -196,7 +199,6 @@ class Boolean(Singular, LogicalMixin):
 
 @attrs.define(auto_attribs=False, repr=False)
 class Array(WithClassifiers, Field):
-
     # WithClassifiers class attrs
     classifiers_attr_name: str = "item_type"
     multiple_classifiers: bool = False


### PR DESCRIPTION
* Better handling in actual_ext for case where file extensions are None
* Allow new_stem when copying a single file
* WithMagicVersion mixin class
* Array conversion from tuple-style string