### PR TITLE
removed __bytes_repr__

### DIFF
--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -834,30 +834,6 @@ class FileSet(DataType):
             file_hashes[str(path)] = crypto_obj.hexdigest()
         return file_hashes
 
-    def __bytes_repr__(
-        self, cache: dict  # pylint: disable=unused-argument
-    ) -> ty.Iterable[bytes]:
-        """Provided for compatibility with Pydra's hashing function, return the contents
-        of all the files in the file-set in chunks
-
-        Parameters
-        ----------
-        cache : dict
-            an object passed around by Pydra's hashing function to store cached versions
-            of previously hashed objects, to allow recursive structures
-
-        Yields
-        ------
-        bytes
-            a chunk of bytes of length FILE_CHUNK_LEN_DEFAULT from the contents of all
-            files in the file-set.
-        """
-        cls = type(self)
-        yield f"{cls.__module__}.{cls.__name__}:".encode()
-        for key, chunk_iter in self.byte_chunks():
-            yield (",'" + key + "'=").encode()
-            yield from chunk_iter
-
     @classmethod
     def referenced_types(cls) -> ty.Set[Classifier]:
         """Returns a flattened list of nested types referenced within the fileset type
@@ -1633,8 +1609,23 @@ class MockMixin:
         assert cls.__name__.endswith("Mock")
         return cls.__name__[: -len("Mock")]
 
-    def __bytes_repr__(self, cache):
-        yield from (str(fspath).encode() for fspath in self.fspaths)
+    def byte_chunks(
+        self,
+        mtime: bool = False,
+        chunk_len=FILE_CHUNK_LEN_DEFAULT,
+        relative_to: ty.Optional[os.PathLike] = None,
+        ignore_hidden_files: bool = False,
+        ignore_hidden_dirs: bool = False,
+    ):
+        if relative_to is None:
+            relative_to = os.path.commonpath(self.fspaths)
+        else:
+            relative_to = str(relative_to)
+        for key, fspath in sorted(
+            ((str(p)[len(relative_to) :], p) for p in self.fspaths),
+            key=itemgetter(0),
+        ):
+            yield (key, iter([key.encode()]))  # empty iterator as files don't exist
 
     @classproperty
     def namespace(cls):

--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -4,8 +4,9 @@ import random
 import shutil
 import time
 import pytest
-from fileformats.core import FileSet, hook
-from fileformats.generic import File, Directory, FsObject
+from fileformats.core import FileSet, MockMixin, hook
+from fileformats.generic import File, Directory, FsObject, SetOf
+from fileformats.text import TextFile
 from fileformats.core.mixin import WithSeparateHeader
 from fileformats.core.exceptions import FileFormatsError
 from conftest import write_test_file
@@ -51,6 +52,11 @@ def fsobject(luigi_file, bowser_dir, request):
         return bowser_dir
     else:
         assert False
+
+
+@pytest.fixture
+def mock_fileset():
+    return SetOf[TextFile].mock("/path/to/a/mock", "/path/to/another/mock")
 
 
 @pytest.fixture
@@ -367,3 +373,10 @@ def test_hash_files(fsobject: FsObject, work_dir: Path, dest_dir: Path):
     )
     cpy = fsobject.copy(dest_dir)
     assert cpy.hash_files() == fsobject.hash_files()
+
+
+def test_hash_mock_files(mock_fileset: MockMixin, work_dir: Path, dest_dir: Path):
+    file_hashes = mock_fileset.hash_files(relative_to="")
+    assert sorted(Path(p) for p in file_hashes) == sorted(
+        p for p in mock_fileset.fspaths
+    )


### PR DESCRIPTION
* Removed __bytes_repr__ implementation from fileset and mock, pydra can call byte_chunks directly
* adds unittest for mock.byte_chunks