### PR TITLE
Fixed FsObject error message to avoid recursion

### DIFF
--- a/fileformats/generic/fsobject.py
+++ b/fileformats/generic/fsobject.py
@@ -14,8 +14,9 @@ class FsObject(FileSet, os.PathLike):  # type: ignore
     @property
     def fspath(self) -> Path:
         if len(self.fspaths) > 1:
+            fspaths = [str(f) for f in self.fspaths]
             raise FormatMismatchError(
-                f"More than one fspath ({self.fspaths}) provided to FsObject, "
+                f"More than one fspath ({fspaths}) provided to FsObject, "
                 f"primary path is ambiguous"
             )
         return next(iter(self.fspaths))


### PR DESCRIPTION
when raising a FormatMismatchError, FsObject recursively attempts to print itself to a string