### PR TITLE
Hardens mtime_cached_property to invalidate the cache for poor mtime resolutions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,6 @@ exclude =
     docs/source/conf.py
 max-line-length = 88
 select = C,E,F,W,B,B950
-extend-ignore = E203,E501,E129,W503
+extend-ignore = E203,E501,E129,W503,E704
 per-file-ignores =
     setup.py:F401

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,45 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.3.0
-      hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: check-yaml
-          - id: check-added-large-files
-    - repo: https://github.com/psf/black
-      rev: 22.3.0
-      hooks:
-          - id: black
-            exclude: ^(fileformats/core/_version\.py)$
-            args:
-                - -l 88
-    - repo: https://github.com/codespell-project/codespell
-      rev: v2.1.0
-      hooks:
-          - id: codespell
-            exclude: ^(fileformats/core/_version\.py)$
-            args:
-                - --ignore-words=.codespell-ignorewords
-    - repo: https://github.com/PyCQA/flake8
-      rev: 4.0.1
-      hooks:
-          - id: flake8
-    - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.11.2
-      hooks:
-          - id: mypy
-            args:
-                [
-                    --strict,
-                    --install-types,
-                    --non-interactive,
-                    --no-warn-unused-ignores,
-                ]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        exclude: ^(fileformats/core/_version\.py)$
+        args:
+          - -l 88
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        exclude: ^(fileformats/core/_version\.py)$
+        args:
+          - --ignore-words=.codespell-ignorewords
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        args:
+          [
+            --strict,
+            --install-types,
+            --non-interactive,
+            --no-warn-unused-ignores,
+            --exclude,
+            tests,
+            --exclude,
+            scripts,
+            --exclude,
+            build,
+          ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,10 +36,5 @@ repos:
             --install-types,
             --non-interactive,
             --no-warn-unused-ignores,
-            --exclude,
-            tests,
-            --exclude,
-            scripts,
-            --exclude,
-            build,
           ]
+        exclude: tests

--- a/fileformats/core/__init__.py
+++ b/fileformats/core/__init__.py
@@ -28,4 +28,5 @@ __all__ = [
     "extra",
     "extra_implementation",
     "converter",
+    "contents_property",
 ]

--- a/fileformats/core/__init__.py
+++ b/fileformats/core/__init__.py
@@ -11,7 +11,7 @@ from .identification import (
 )
 from .sampling import SampleFileGenerator
 from .extras import extra, extra_implementation, converter
-from .decorators import contents_property
+from .decorators import mtime_cached_property
 
 __all__ = [
     "__version__",
@@ -28,5 +28,5 @@ __all__ = [
     "extra",
     "extra_implementation",
     "converter",
-    "contents_property",
+    "mtime_cached_property",
 ]

--- a/fileformats/core/__init__.py
+++ b/fileformats/core/__init__.py
@@ -11,6 +11,7 @@ from .identification import (
 )
 from .sampling import SampleFileGenerator
 from .extras import extra, extra_implementation, converter
+from .decorators import contents_property
 
 __all__ = [
     "__version__",

--- a/fileformats/core/classifier.py
+++ b/fileformats/core/classifier.py
@@ -1,5 +1,5 @@
 import typing as ty
-from .utils import classproperty
+from .decorators import classproperty
 from .exceptions import FormatDefinitionError
 
 

--- a/fileformats/core/datatype.py
+++ b/fileformats/core/datatype.py
@@ -11,8 +11,8 @@ from .exceptions import (
     FormatConversionError,
     FormatRecognitionError,
 )
+from .decorators import classproperty
 from .utils import (
-    classproperty,
     subpackages,
     add_exc_note,
 )

--- a/fileformats/core/decorators.py
+++ b/fileformats/core/decorators.py
@@ -121,4 +121,8 @@ def enough_time_has_elapsed_given_mtime_resolution(
     if current_time is None:
         current_time = time.time_ns()
     elapsed_time = current_time - max_mtime
+    raise Exception(
+        f"current_time: {current_time}, max_mtime: {max_mtime}, "
+        f"elapsed_time: {elapsed_time}, guessed_mtime_res: {guessed_mtime_res}"
+    )
     return elapsed_time > guessed_mtime_res

--- a/fileformats/core/decorators.py
+++ b/fileformats/core/decorators.py
@@ -1,12 +1,10 @@
 import sys
 import typing as ty
 from threading import RLock
-
-if ty.TYPE_CHECKING:
-    import fileformats.core
+import fileformats.core
 
 
-ReturnType = ty.TypeVar("ReturnType")
+PropReturn = ty.TypeVar("PropReturn")
 
 
 class contents_property:
@@ -55,9 +53,6 @@ class contents_property:
             value = self.func(instance)
             instance.__dict__[self._cache_name] = (instance.mtimes, value)
         return value
-
-
-PropReturn = ty.TypeVar("PropReturn")
 
 
 def classproperty(meth: ty.Callable[..., PropReturn]) -> PropReturn:

--- a/fileformats/core/decorators.py
+++ b/fileformats/core/decorators.py
@@ -78,8 +78,9 @@ def enough_time_has_elapsed_given_mtime_resolution(
     """Determines whether enough time has elapsed since the the last of the cached mtimes
     to be sure that changes in mtimes will be detected given the resolution of the mtimes
     on the file system. For example, on systems with a mtime resolution of a second,
-    a change in mtime may not be detected if the cache is read within a second of the
-    file being modified. So this function guesses the resolution of the mtimes by the
+    a change in mtime may not be detected if the cache is re-read within a second and
+    the file is modified in the intervening period (probably only likely during tests).
+    So this function guesses the resolution of the mtimes by the
     minimum number of trailing zeros in the mtimes and then checks if enough time has
     passed to be sure that any changes in mtimes will be detected.
 

--- a/fileformats/core/decorators.py
+++ b/fileformats/core/decorators.py
@@ -19,14 +19,7 @@ class mtime_cached_property:
         self.func = func
         self.__doc__ = func.__doc__
         self.lock = RLock()
-
-    @property
-    def _cache_name(self) -> str:
-        return f"_{self.func.__name__}_mtime_cache"
-
-    def clear(self, instance: "fileformats.core.FileSet") -> None:
-        """Forcibly clear the cache"""
-        del instance.__dict__[self._cache_name]
+        self._cache_name = f"_{func.__name__}_mtime_cache"
 
     def __get__(
         self,

--- a/fileformats/core/decorators.py
+++ b/fileformats/core/decorators.py
@@ -1,0 +1,76 @@
+import sys
+import typing as ty
+from threading import RLock
+
+if ty.TYPE_CHECKING:
+    import fileformats.core
+
+
+ReturnType = ty.TypeVar("ReturnType")
+
+
+class contents_property:
+    """A property that is cached until the mtimes of the files in the fileset are changed"""
+
+    def __init__(self, func: ty.Callable[..., ty.Any]):
+        self.func = func
+        self.__doc__ = func.__doc__
+        self.lock = RLock()
+
+    @property
+    def _cache_name(self) -> str:
+        return f"_{self.func.__name__}_mtime_cache"
+
+    def clear(self, instance: "fileformats.core.FileSet") -> None:
+        """Forcibly clear the cache"""
+        del instance.__dict__[self._cache_name]
+
+    def __get__(
+        self,
+        instance: ty.Optional["fileformats.core.FileSet"],
+        owner: ty.Optional[ty.Type["fileformats.core.FileSet"]] = None,
+    ) -> ty.Any:
+        if instance is None:  # if accessing property from class not instance
+            return self
+        assert isinstance(instance, fileformats.core.FileSet), (
+            "Cannot use contents_property instance with "
+            f"{type(instance).__name__!r} object, only FileSet objects."
+        )
+        try:
+            mtimes, value = instance.__dict__[self._cache_name]
+        except KeyError:
+            pass
+        else:
+            if instance.mtimes == mtimes:
+                return value
+        with self.lock:
+            # check if another thread filled cache while we awaited lock
+            try:
+                mtimes, value = instance.__dict__[self._cache_name]
+            except KeyError:
+                pass
+            else:
+                if instance.mtimes == mtimes:
+                    return value
+            value = self.func(instance)
+            instance.__dict__[self._cache_name] = (instance.mtimes, value)
+        return value
+
+
+PropReturn = ty.TypeVar("PropReturn")
+
+
+def classproperty(meth: ty.Callable[..., PropReturn]) -> PropReturn:
+    """Access a @classmethod like a @property."""
+    # mypy doesn't understand class properties yet: https://github.com/python/mypy/issues/2563
+    return classmethod(property(meth))  # type: ignore
+
+
+if sys.version_info[:2] < (3, 9):
+
+    class classproperty(object):  # type: ignore[no-redef]  # noqa
+        def __init__(self, f: ty.Callable[[ty.Type[ty.Any]], ty.Any]):
+            self.f = f
+
+        def __get__(self, obj: ty.Any, owner: ty.Any) -> ty.Any:
+            return self.f(owner)

--- a/fileformats/core/decorators.py
+++ b/fileformats/core/decorators.py
@@ -9,10 +9,10 @@ import fileformats.core
 PropReturn = ty.TypeVar("PropReturn")
 
 
-__all__ = ["contents_property", "classproperty"]
+__all__ = ["mtime_cached_property", "classproperty"]
 
 
-class contents_property:
+class mtime_cached_property:
     """A property that is cached until the mtimes of the files in the fileset are changed"""
 
     def __init__(self, func: ty.Callable[..., ty.Any]):
@@ -36,7 +36,7 @@ class contents_property:
         if instance is None:  # if accessing property from class not instance
             return self
         assert isinstance(instance, fileformats.core.FileSet), (
-            "Cannot use contents_property instance with "
+            "Cannot use mtime_cached_property instance with "
             f"{type(instance).__name__!r} object, only FileSet objects."
         )
         try:

--- a/fileformats/core/decorators.py
+++ b/fileformats/core/decorators.py
@@ -115,5 +115,8 @@ def enough_time_has_elapsed_given_mtime_resolution(
         raise ValueError("No mtimes provided")
     if current_time is None:
         current_time = time.time_ns()
+    raise Exception(
+        f"current_time: {current_time}, max_mtime: {max_mtime}, guessed_mtime_res: {guessed_mtime_res}"
+    )
     elapsed_time = current_time - max_mtime
     return elapsed_time > guessed_mtime_res

--- a/fileformats/core/field.py
+++ b/fileformats/core/field.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 import typing as ty
-from .utils import (
-    classproperty,
-)
+from .decorators import classproperty
 from .datatype import DataType
 from .exceptions import FormatMismatchError
 

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -186,14 +186,14 @@ class FileSet(DataType):
         return (p.relative_to(self.parent) for p in self.fspaths)
 
     @property
-    def mtimes(self) -> ty.Tuple[ty.Tuple[str, float], ...]:
+    def mtimes(self) -> ty.Tuple[ty.Tuple[str, int], ...]:
         """Modification times of all fspaths in the file-set
 
         Returns
         -------
-        tuple[tuple[str, float], ...]
-            a tuple of tuples containing the file paths and the modification time sorted
-            by the file path
+        tuple[tuple[str, int], ...]
+            a tuple of tuples containing the file paths and the modification time (ns)
+            sorted by the file path
         """
         return tuple((str(p), p.stat().st_mtime_ns) for p in sorted(self.fspaths))
 

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -21,7 +21,7 @@ from .utils import (
     matching_source,
     import_extras_module,
 )
-from .decorators import contents_property, classproperty
+from .decorators import mtime_cached_property, classproperty
 from .typing import FspathsInputType, CryptoMethod, PathType
 from .sampling import SampleFileGenerator
 from .identification import (
@@ -243,7 +243,7 @@ class FileSet(DataType):
             pass
         return possible
 
-    @contents_property
+    @mtime_cached_property
     def metadata(self) -> ty.Mapping[str, ty.Any]:
         """Lazily load metadata from `read_metadata` extra if implemented, returning an
         empty metadata array if not"""

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -195,7 +195,7 @@ class FileSet(DataType):
             a tuple of tuples containing the file paths and the modification time sorted
             by the file path
         """
-        return tuple((str(p), p.stat().st_mtime) for p in sorted(self.fspaths))
+        return tuple((str(p), p.stat().st_mtime_ns) for p in sorted(self.fspaths))
 
     @classproperty
     def mime_type(cls) -> str:

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -16,13 +16,12 @@ import hashlib
 import logging
 from fileformats.core.typing import Self
 from .utils import (
-    classproperty,
-    mtime_cached_property,
     fspaths_converter,
     describe_task,
     matching_source,
     import_extras_module,
 )
+from .decorators import contents_property, classproperty
 from .typing import FspathsInputType, CryptoMethod, PathType
 from .sampling import SampleFileGenerator
 from .identification import (
@@ -244,7 +243,7 @@ class FileSet(DataType):
             pass
         return possible
 
-    @mtime_cached_property
+    @contents_property
     def metadata(self) -> ty.Mapping[str, ty.Any]:
         """Lazily load metadata from `read_metadata` extra if implemented, returning an
         empty metadata array if not"""

--- a/fileformats/core/fs_mount_identifier.py
+++ b/fileformats/core/fs_mount_identifier.py
@@ -171,15 +171,15 @@ class FsMountIdentifier:
             the root of the mount the path sits on
         fstype : str
             the type of the file-system (e.g. ext4 or cifs)"""
-        mount_point, fstype = cls.get_mount(path)
-        try:
-            resolution = cls.FS_MTIME_NS_RESOLUTION[fstype]
-        except KeyError:
-            try:
-                resolution = cls.measure_mtime_resolution(mount_point)
-            except (RuntimeError, OSError):
-                # Fallback to the largest known mtime
-                resolution = max(cls.FS_MTIME_NS_RESOLUTION.values())
+        mount_point, _ = cls.get_mount(path)
+        # try:
+        #     resolution = cls.FS_MTIME_NS_RESOLUTION[fstype]
+        # except KeyError:
+        #     try:
+        resolution = cls.measure_mtime_resolution(mount_point)
+        # except (RuntimeError, OSError):
+        #     # Fallback to the largest known mtime
+        #     resolution = max(cls.FS_MTIME_NS_RESOLUTION.values())
         return resolution
 
     @classmethod

--- a/fileformats/core/fs_mount_identifier.py
+++ b/fileformats/core/fs_mount_identifier.py
@@ -156,3 +156,33 @@ class FsMountIdentifier:
             cls._mount_table = orig_table
 
     _mount_table: ty.Optional[ty.List[ty.Tuple[str, str]]] = None
+
+
+# # Define a table of file system types and their mtime resolutions (in seconds)
+# FS_MTIME_NS_RESOLUTION = {
+#     "ext4": 1,  # 1 nanosecond
+#     "xfs": 1,  # 1 nanosecond
+#     "btrfs": 1,  # 1 nanosecond
+#     "ntfs": 100,  # 100 nanoseconds
+#     "hfs": 1,  # 1 nanosecond
+#     "apfs": 1,  # 1 nanosecond
+#     "fat32": 2e9,  # 2 seconds (2 * 10^9 nanoseconds)
+#     "exfat": 1e9,  # 1 second (1 * 10^9 nanoseconds)
+#     # Add more file systems and their resolutions as needed
+# }
+
+
+# def measure_mtime_resolution(file_path: str) -> float:
+#     # Get the initial mtime
+#     initial_mtime = os.path.getmtime(file_path)
+
+#     # Wait for a very short period and update the mtime using touch
+#     for sleep_time in [0.001, 0.01, 0.1, 1]:  # 1ms, 10ms, 100ms, 1s
+#         time.sleep(sleep_time)
+#         touch(file_path)
+#         new_mtime = os.path.getmtime(file_path)
+#         if new_mtime != initial_mtime:
+#             # Calculate the resolution
+#             resolution = new_mtime - initial_mtime
+#             return resolution
+#     return None

--- a/fileformats/core/fs_mount_identifier.py
+++ b/fileformats/core/fs_mount_identifier.py
@@ -202,6 +202,7 @@ class FsMountIdentifier:
                 for tmp_file in tmp_files:
                     tmp_file.touch()
                 new_mtimes = [t.lstat().st_mtime_ns for t in tmp_files]
+                print(new_mtimes, initial_mtimes)
                 if all(n != i for n, i in zip(new_mtimes, initial_mtimes)):
                     # Calculate the resolution
                     return max(n - i for n, i in zip(new_mtimes, initial_mtimes))
@@ -210,7 +211,8 @@ class FsMountIdentifier:
                 "is stored on"
             )
         finally:
-            tmp_file.unlink()
+            for tmp_file in tmp_files:
+                tmp_file.unlink()
 
     _mount_table: ty.Optional[ty.List[ty.Tuple[str, str]]] = None
     # _inode_size_table: ty.Dict[str, int] = {}

--- a/fileformats/core/mixin.py
+++ b/fileformats/core/mixin.py
@@ -4,7 +4,8 @@ import typing as ty
 import logging
 from .datatype import DataType
 import fileformats.core
-from .utils import classproperty, describe_task, matching_source
+from .utils import describe_task, matching_source
+from .decorators import classproperty
 from .identification import to_mime_format_name
 from .converter_helpers import SubtypeVar, ConverterSpec
 from .classifier import Classifier

--- a/fileformats/core/tests/test_decorators.py
+++ b/fileformats/core/tests/test_decorators.py
@@ -1,5 +1,8 @@
 from pathlib import Path
-from fileformats.core.decorators import mtime_cached_property
+from fileformats.core.decorators import (
+    mtime_cached_property,
+    enough_time_has_elapsed_given_mtime_resolution,
+)
 from fileformats.generic import File
 
 
@@ -24,3 +27,15 @@ def test_mtime_cached_property(tmp_path: Path):
     assert file.cached_prop == 0
     fspath.write_text("world")
     assert file.cached_prop == 1
+
+
+def test_enough_time_has_elapsed_given_mtime_resolution():
+    assert enough_time_has_elapsed_given_mtime_resolution(
+        [("", 110), ("", 220), ("", 300)], 311
+    )
+
+
+def test_not_enough_time_has_elapsed_given_mtime_resolution():
+    assert not enough_time_has_elapsed_given_mtime_resolution(
+        [("", 110), ("", 220), ("", 300)], 301
+    )

--- a/fileformats/core/tests/test_decorators.py
+++ b/fileformats/core/tests/test_decorators.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import time
 from fileformats.core.decorators import (
     mtime_cached_property,
     enough_time_has_elapsed_given_mtime_resolution,
@@ -20,6 +21,9 @@ def test_mtime_cached_property(tmp_path: Path):
     fspath.write_text("hello")
 
     file = MtimeTestFile(fspath)
+    time.sleep(
+        2
+    )  # ensure enough time has elapsed since file creation/modification for mtime to increment
 
     file.flag = 0
     assert file.cached_prop == 0
@@ -31,7 +35,7 @@ def test_mtime_cached_property(tmp_path: Path):
 
 def test_enough_time_has_elapsed_given_mtime_resolution():
     assert enough_time_has_elapsed_given_mtime_resolution(
-        [("", 110), ("", 220), ("", 300)], 311
+        [("", 110), ("", 220), ("", 300)], int(3e9)  # need to make it high for windows
     )
 
 

--- a/fileformats/core/tests/test_decorators.py
+++ b/fileformats/core/tests/test_decorators.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import time
-from fileformats.core.decorators import contents_property
+from fileformats.core.decorators import mtime_cached_property
 from fileformats.generic import File
 
 
@@ -8,12 +8,12 @@ class MtimeTestFile(File):
 
     flag: int
 
-    @contents_property
+    @mtime_cached_property
     def cached_prop(self):
         return self.flag
 
 
-def test_contents_property(tmp_path: Path):
+def test_mtime_cached_property(tmp_path: Path):
     fspath = tmp_path / "file_1.txt"
     fspath.write_text("hello")
 
@@ -32,7 +32,7 @@ def test_contents_property(tmp_path: Path):
     assert file.cached_prop == 1
 
 
-def test_contents_property_force_clear(tmp_path: Path):
+def test_mtime_cached_property_force_clear(tmp_path: Path):
     fspath = tmp_path / "file_1.txt"
     fspath.write_text("hello")
 

--- a/fileformats/core/tests/test_decorators.py
+++ b/fileformats/core/tests/test_decorators.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import time
+from fileformats.core.decorators import contents_property
+from fileformats.generic import File
+
+
+class MtimeTestFile(File):
+
+    flag: int
+
+    @contents_property
+    def cached_prop(self):
+        return self.flag
+
+
+def test_contents_property(tmp_path: Path):
+    fspath = tmp_path / "file_1.txt"
+    fspath.write_text("hello")
+
+    file = MtimeTestFile(fspath)
+
+    file.flag = 0
+    assert file.cached_prop == 0
+    # Need a long delay to ensure the mtime changes on Ubuntu and particularly on Windows
+    # On MacOS, the mtime resolution is much higher so not usually an issue. Use
+    # explicitly cache clearing if needed
+    time.sleep(2)
+    file.flag = 1
+    assert file.cached_prop == 0
+    time.sleep(2)
+    fspath.write_text("world")
+    assert file.cached_prop == 1
+
+
+def test_contents_property_force_clear(tmp_path: Path):
+    fspath = tmp_path / "file_1.txt"
+    fspath.write_text("hello")
+
+    file = MtimeTestFile(fspath)
+
+    file.flag = 0
+    assert file.cached_prop == 0
+    file.flag = 1
+    MtimeTestFile.cached_prop.clear(file)
+    assert file.cached_prop == 1

--- a/fileformats/core/tests/test_decorators.py
+++ b/fileformats/core/tests/test_decorators.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import time
 from fileformats.core.decorators import mtime_cached_property
 from fileformats.generic import File
 
@@ -21,25 +20,7 @@ def test_mtime_cached_property(tmp_path: Path):
 
     file.flag = 0
     assert file.cached_prop == 0
-    # Need a long delay to ensure the mtime changes on Ubuntu and particularly on Windows
-    # On MacOS, the mtime resolution is much higher so not usually an issue. Use
-    # explicitly cache clearing if needed
-    time.sleep(2)
     file.flag = 1
     assert file.cached_prop == 0
-    time.sleep(2)
     fspath.write_text("world")
-    assert file.cached_prop == 1
-
-
-def test_mtime_cached_property_force_clear(tmp_path: Path):
-    fspath = tmp_path / "file_1.txt"
-    fspath.write_text("hello")
-
-    file = MtimeTestFile(fspath)
-
-    file.flag = 0
-    assert file.cached_prop == 0
-    file.flag = 1
-    MtimeTestFile.cached_prop.clear(file)
     assert file.cached_prop == 1

--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -8,7 +8,6 @@ from fileformats.core import FileSet
 from fileformats.generic import File, Directory, FsObject
 from fileformats.core.mixin import WithSeparateHeader
 from fileformats.core.exceptions import UnsatisfiableCopyModeError
-from fileformats.core.utils import mtime_cached_property
 from conftest import write_test_file
 
 
@@ -366,44 +365,3 @@ def test_hash_files(fsobject: FsObject, work_dir: Path, dest_dir: Path):
     )
     cpy = fsobject.copy(dest_dir)
     assert cpy.hash_files() == fsobject.hash_files()
-
-
-class MtimeTestFile(File):
-
-    flag: int
-
-    @mtime_cached_property
-    def cached_prop(self):
-        return self.flag
-
-
-def test_mtime_cached_property(tmp_path: Path):
-    fspath = tmp_path / "file_1.txt"
-    fspath.write_text("hello")
-
-    file = MtimeTestFile(fspath)
-
-    file.flag = 0
-    assert file.cached_prop == 0
-    # Need a long delay to ensure the mtime changes on Ubuntu and particularly on Windows
-    # On MacOS, the mtime resolution is much higher so not usually an issue. Use
-    # explicitly cache clearing if needed
-    time.sleep(2)
-    file.flag = 1
-    assert file.cached_prop == 0
-    time.sleep(2)
-    fspath.write_text("world")
-    assert file.cached_prop == 1
-
-
-def test_mtime_cached_property_force_clear(tmp_path: Path):
-    fspath = tmp_path / "file_1.txt"
-    fspath.write_text("hello")
-
-    file = MtimeTestFile(fspath)
-
-    file.flag = 0
-    assert file.cached_prop == 0
-    file.flag = 1
-    MtimeTestFile.cached_prop.clear(file)
-    assert file.cached_prop == 1

--- a/fileformats/generic/directory.py
+++ b/fileformats/generic/directory.py
@@ -1,7 +1,7 @@
 import typing as ty
 from pathlib import Path
 from fileformats.core.exceptions import FormatMismatchError
-from fileformats.core.utils import classproperty
+from fileformats.core.decorators import classproperty
 from .fsobject import FsObject
 from fileformats.core.fileset import FileSet, FILE_CHUNK_LEN_DEFAULT
 from fileformats.core.mixin import WithClassifiers

--- a/fileformats/generic/file.py
+++ b/fileformats/generic/file.py
@@ -6,7 +6,7 @@ from fileformats.core.exceptions import (
     FormatMismatchError,
     UnconstrainedExtensionException,
 )
-from fileformats.core.decorators import classproperty, contents_property
+from fileformats.core.decorators import classproperty, mtime_cached_property
 from .fsobject import FsObject
 
 
@@ -80,7 +80,7 @@ class File(FsObject):
         )
         return Path(new_path).with_suffix(suffix)
 
-    @contents_property
+    @mtime_cached_property
     def contents(self) -> ty.Union[str, bytes]:
         return self.read_contents()
 

--- a/fileformats/generic/file.py
+++ b/fileformats/generic/file.py
@@ -1,3 +1,4 @@
+import io
 from pathlib import Path
 import typing as ty
 from fileformats.core.fileset import FileSet
@@ -5,7 +6,7 @@ from fileformats.core.exceptions import (
     FormatMismatchError,
     UnconstrainedExtensionException,
 )
-from fileformats.core.utils import classproperty, mtime_cached_property
+from fileformats.core.decorators import classproperty, contents_property
 from .fsobject import FsObject
 
 
@@ -79,7 +80,7 @@ class File(FsObject):
         )
         return Path(new_path).with_suffix(suffix)
 
-    @mtime_cached_property
+    @contents_property
     def contents(self) -> ty.Union[str, bytes]:
         return self.read_contents()
 
@@ -107,7 +108,7 @@ class File(FsObject):
     ) -> ty.Union[str, bytes]:
         with self.open() as f:
             if offset:
-                f.read(offset)
+                f.seek(offset, (io.SEEK_SET if offset >= 0 else io.SEEK_END))
             contents = f.read(size) if size else f.read()
         return contents
 

--- a/fileformats/generic/fsobject.py
+++ b/fileformats/generic/fsobject.py
@@ -6,7 +6,7 @@ from fileformats.core.fileset import FileSet
 from fileformats.core.exceptions import (
     FormatMismatchError,
 )
-from fileformats.core.utils import classproperty
+from fileformats.core.decorators import classproperty
 
 
 class FsObject(FileSet, os.PathLike):  # type: ignore

--- a/fileformats/generic/set.py
+++ b/fileformats/generic/set.py
@@ -3,7 +3,7 @@ from fileformats.core.fileset import FileSet
 from fileformats.core.exceptions import (
     FormatMismatchError,
 )
-from fileformats.core.decorators import contents_property
+from fileformats.core.decorators import mtime_cached_property
 from fileformats.core.mixin import WithClassifiers
 
 
@@ -13,7 +13,7 @@ class TypedSet(FileSet):
 
     content_types: ty.Tuple[ty.Type[FileSet], ...] = ()
 
-    @contents_property
+    @mtime_cached_property
     def contents(self) -> ty.Iterable[FileSet]:
         for content_type in self.content_types:
             for p in self.fspaths:

--- a/fileformats/generic/set.py
+++ b/fileformats/generic/set.py
@@ -3,7 +3,7 @@ from fileformats.core.fileset import FileSet
 from fileformats.core.exceptions import (
     FormatMismatchError,
 )
-from fileformats.core.utils import mtime_cached_property
+from fileformats.core.decorators import contents_property
 from fileformats.core.mixin import WithClassifiers
 
 
@@ -13,7 +13,7 @@ class TypedSet(FileSet):
 
     content_types: ty.Tuple[ty.Type[FileSet], ...] = ()
 
-    @mtime_cached_property
+    @contents_property
     def contents(self) -> ty.Iterable[FileSet]:
         for content_type in self.content_types:
             for p in self.fspaths:

--- a/fileformats/image/raster.py
+++ b/fileformats/image/raster.py
@@ -23,11 +23,11 @@ class RasterImage(Image):
 
     @extra
     def read_data(self) -> DataArrayType:
-        raise NotImplementedError
+        ...
 
     @extra
     def write_data(self, data_array: DataArrayType) -> None:
-        raise NotImplementedError
+        ...
 
     @classmethod
     def save_new(cls, fspath: Path, data_array: DataArrayType) -> Self:


### PR DESCRIPTION
* Guesses the mtime resolution from the file system type (taking conservative estimates, e.g. ext4 -> 1 sec)
* Checks that enough time has passed since the last of the cached mtimes to be sure that no writes could have occurred between re-reads and the mtimes stay the same