### PR TITLE
Adds BinaryIOWindow class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI/CD](https://github.com/arcanaframework/fileformats/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/arcanaframework/fileformats/actions/workflows/ci-cd.yml)
 [![Codecov](https://codecov.io/gh/arcanaframework/fileformats/branch/main/graph/badge.svg?token=UIS0OGPST7)](https://codecov.io/gh/arcanaframework/fileformats)
+[![Code style: black](https://camo.githubusercontent.com/5bf9e9fa18966df7cb5fac7715bef6b72df15e01a6efa9d616c83f9fcb527fe2/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f636f64652532307374796c652d626c61636b2d3030303030302e737667)](https://github.com/psf/black)
+![Static Badge](https://img.shields.io/badge/type%20checked-mypy-039dfc)
 [![Python Versions](https://img.shields.io/pypi/pyversions/fileformats.svg)](https://pypi.python.org/pypi/fileformats/)
 [![Latest Version](https://img.shields.io/pypi/v/fileformats.svg)](https://pypi.python.org/pypi/fileformats/)
 [![Documentation Status](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](https://arcanaframework.github.io/fileformats/)

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -328,7 +328,14 @@ class FileSet(DataType):
             prop = getattr(self, prop_name)
             paths = []
             if hasattr(prop, "required_paths"):
-                paths = prop.required_paths()
+                try:
+                    paths = prop.required_paths()
+                except RecursionError:
+                    warn(
+                        f"Recursion error when trying to get required paths from {prop_name} "
+                        f"property of {type(self)}"
+                    )
+                    raise
             elif isinstance(prop, os.PathLike):
                 paths = [Path(prop)]
             elif isinstance(prop, ty.Iterable):

--- a/fileformats/core/io.py
+++ b/fileformats/core/io.py
@@ -1,0 +1,168 @@
+import io
+import typing as ty
+from types import TracebackType
+
+
+class BinaryIOWindow(ty.BinaryIO):
+    """Presents a window onto an underlying BinaryIO object in a duck-typable
+    subclass, so functions that take a stream object can be presented a partial view
+    onto a file-stream. Can be useful where a header file is appended to a binary file
+    e.g. DICOM header on Siemens raw PET data files.
+
+    Parameters
+    ----------
+    binary_io: ty.BinaryIO
+        the base stream to be windowed
+    start: int
+        start of the window, if negative then interpreted as being from the end of the stream
+    end: int, optional
+        end of the window, if negative then interpreted as being from the end of the stream,
+        if None then the end of the stream, by default None
+    """
+
+    wrapped_io: ty.BinaryIO
+    start: int
+    end: int
+
+    def __init__(
+        self, binary_io: ty.BinaryIO, start: int, end: ty.Optional[int] = None
+    ):
+        if binary_io.seekable() is False:
+            binary_io = io.BytesIO(binary_io.read())
+        self.wrapped_io = binary_io
+        self.wrapped_io.seek(0, io.SEEK_END)
+        file_size = self.wrapped_io.tell()
+        if end is None:
+            end = file_size
+        if start >= 0:
+            self.start = start
+        else:
+            self.start = file_size + start
+            if self.start < 0:
+                raise ValueError(
+                    f"Start position {start} is before the start of the file ({file_size})"
+                )
+        if end >= 0:
+            if end > file_size:
+                raise ValueError(
+                    f"End position {end} is beyond end of the file ({file_size})"
+                )
+            self.end = end
+        else:
+            self.end = file_size + end
+        if self.end < self.start:
+            raise ValueError(
+                f"End position, {end}, is before start position, {start}, for file of "
+                f"size {file_size}"
+            )
+        self.size = self.end - self.start
+        self.wrapped_io.seek(self.start)
+
+    def read(self, size: ty.Optional[int] = -1) -> bytes:
+        current_pos = self.tell()
+        if current_pos >= self.size:
+            return b""
+        if size is None or size < 0 or (current_pos + size) > self.size:
+            size = self.size - current_pos
+        return self.wrapped_io.read(size)
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        if whence == io.SEEK_SET:
+            ref = self.start
+        elif whence == io.SEEK_CUR:
+            ref = self.wrapped_io.tell()
+        elif whence == io.SEEK_END:
+            ref = self.end
+        else:
+            raise ValueError(
+                f"Invalid value for 'whence' {whence}, should be 0, 1, or 2 "
+                "(io.SEEK_SET, io.SEEK_CUR, io.SEEK_END)"
+            )
+        return self.wrapped_io.seek(ref + offset)
+
+    def tell(self) -> int:
+        return self.wrapped_io.tell() - self.start
+
+    def __iter__(self) -> ty.Iterator[bytes]:
+        self.seek(0)
+        return self
+
+    def __next__(self) -> bytes:
+        line = self.readline()
+        if not line:
+            raise StopIteration
+        return line
+
+    @property
+    def mode(self) -> str:
+        return self.wrapped_io.mode
+
+    @property
+    def name(self) -> str:
+        return self.wrapped_io.name
+
+    def close(self) -> None:
+        self.wrapped_io.close()
+
+    @property
+    def closed(self) -> bool:
+        return self.wrapped_io.closed
+
+    def fileno(self) -> int:
+        return self.wrapped_io.fileno()
+
+    def flush(self) -> None:
+        raise NotImplementedError
+
+    def isatty(self) -> bool:
+        return self.wrapped_io.isatty()
+
+    def readable(self) -> bool:
+        return self.wrapped_io.readable()
+
+    def readline(self, limit: int = -1) -> bytes:
+        current_pos = self.tell()
+        if current_pos >= self.size:
+            return b""
+        line = self.wrapped_io.readline()
+        if current_pos + len(line) > self.size:
+            line = line[: (self.size - current_pos)]
+        return line
+
+    def readlines(self, hint: int = -1) -> ty.List[bytes]:
+        lines = []
+        total_bytes = 0
+        for line in self:
+            lines.append(line)
+            total_bytes += len(line)
+            if hint > 0 and total_bytes >= hint:
+                break
+        return lines
+
+    def seekable(self) -> bool:
+        assert self.wrapped_io.seekable()
+        return True
+
+    def truncate(self, size: ty.Optional[int] = None) -> int:
+        raise NotImplementedError
+
+    def writable(self) -> bool:
+        return False
+
+    def write(self, s: bytes) -> int:  # type: ignore[override]
+        raise NotImplementedError
+
+    def writelines(self, lines: ty.Iterable[bytes]) -> None:  # type: ignore[override]
+        raise NotImplementedError
+
+    def __enter__(self) -> ty.BinaryIO:
+        self.wrapped_io.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        type: ty.Optional[ty.Type[BaseException]],
+        value: ty.Optional[BaseException],
+        traceback: ty.Optional[TracebackType],
+    ) -> None:
+        return self.wrapped_io.__exit__(type, value, traceback)

--- a/fileformats/core/mixin.py
+++ b/fileformats/core/mixin.py
@@ -712,10 +712,9 @@ class WithClassifiers:
     def type_name(cls) -> str:
         """Name of type including classifiers to be used in __repr__"""
         unclassified: str
-        if cls.is_classified:
-            unclassified = cls.unclassified.__name__  # type: ignore[attr-defined]
-        else:
-            unclassified = type(cls).__name__
+        if not cls.is_classified:
+            return cls.__name__  # type: ignore[no-any-return, attr-defined]
+        unclassified = cls.unclassified.__name__  # type: ignore[attr-defined]
         return (
             unclassified + "[" + ", ".join(t.type_name for t in cls.classifiers) + "]"
         )

--- a/fileformats/core/tests/test_identification.py
+++ b/fileformats/core/tests/test_identification.py
@@ -2,11 +2,12 @@ from collections import Counter
 import itertools
 import typing as ty
 import pytest
-from fileformats.core.identification import (
+from fileformats.core import (
     find_matching,
     to_mime,
     from_mime,
     from_paths,
+    FileSet,
 )
 from fileformats.core.exceptions import FormatRecognitionError
 from fileformats.testing import Foo, Bar
@@ -56,6 +57,11 @@ def test_to_from_list_union_mime_roundtrip():
 def test_official_mime_fail():
     with pytest.raises(TypeError, match="as it is not a proper file-type"):
         to_mime(ty.List[Foo], official=True)
+
+
+def test_repr():
+    for frmt in FileSet.all_formats:
+        assert repr(frmt.mock("/a/path")).startswith(f"{frmt.__name__}(")
 
 
 def test_from_paths(tmp_path):

--- a/fileformats/core/tests/test_io.py
+++ b/fileformats/core/tests/test_io.py
@@ -1,0 +1,114 @@
+import io
+import pytest
+from pathlib import Path
+from fileformats.core.io import BinaryIOWindow
+
+
+def test_binary_window():
+
+    data = b"0123456789abcdefghijklmnopqrstuvwxyz"
+    with BinaryIOWindow(io.BytesIO(data), start=10, end=25) as window:
+        assert window.read() == b"abcdefghijklmno"
+        assert window.tell() == 15
+        window.seek(0)
+        assert window.read(3) == b"abc"
+        assert window.tell() == 3
+        window.seek(3, io.SEEK_CUR)
+        assert window.read(3) == b"ghi"
+        window.seek(-3, io.SEEK_END)
+        assert window.read() == b"mno"
+        window.seek(3)
+        assert window.read(3) == b"def"
+        assert window.tell() == 6
+        with pytest.raises(ValueError):
+            window.seek(0, 3)
+    assert window.closed
+
+
+def test_binary_window_no_end():
+
+    data = b"0123456789abcdefghijklmnopqrstuvwxyz"
+    with BinaryIOWindow(io.BytesIO(data), start=10) as window:
+        assert window.read() == b"abcdefghijklmnopqrstuvwxyz"
+
+
+def test_binary_window_attrs():
+    data = b"abc"
+    with BinaryIOWindow(io.BytesIO(data), start=1, end=-1) as window:
+        assert window.readable()
+        assert not window.closed
+        assert window.seekable()
+        assert not window.writable()
+
+
+def test_binary_window_negative():
+    data = b"abcdefghijklmnopqrstuvwxyz0123456789"
+    with BinaryIOWindow(io.BytesIO(data), start=-20, end=-10) as window:
+        assert window.read() == b"qrstuvwxyz"
+        assert window.tell() == 10
+        window.seek(0)
+        assert window.read(3) == b"qrs"
+        assert window.tell() == 3
+        window.seek(-3, io.SEEK_END)
+        assert window.read() == b"xyz"
+        assert window.tell() == 10
+
+
+def test_binary_window_readlines():
+    data = b"abc\ndef\nghi\njkl\n"
+    with BinaryIOWindow(io.BytesIO(data), start=4, end=-4) as window:
+        assert window.readlines() == [b"def\n", b"ghi\n"]
+        window.seek(0)
+        assert next(window) == b"def\n"
+        assert window.tell() == 4
+        assert window.readline() == b"ghi\n"
+        assert list(window) == [b"def\n", b"ghi\n"]
+
+
+def test_binary_window_write():
+    data = b"abc"
+    with BinaryIOWindow(io.BytesIO(data), start=1, end=-1) as window:
+        with pytest.raises(NotImplementedError):
+            window.write(b"test")
+        with pytest.raises(NotImplementedError):
+            window.writelines([b"test"])
+        with pytest.raises(NotImplementedError):
+            window.truncate()
+        with pytest.raises(NotImplementedError):
+            window.flush()
+
+
+def test_binary_window_misc(tmp_path: Path):
+    test_file = tmp_path / "test.txt"
+    test_file.write_bytes(b"12345abcdefghij1234567890")
+    with BinaryIOWindow(test_file.open("rb"), start=5, end=-10) as window:
+        assert window.read() == b"abcdefghij"
+        assert window.tell() == 10
+        window.seek(0)
+        assert window.fileno() > 0
+        assert window.mode == "rb"
+        assert window.isatty() is False
+        assert window.name == str(test_file)
+
+
+def test_binary_window_open_close():
+    data = b"abc"
+    window = BinaryIOWindow(io.BytesIO(data), start=1, end=-1)
+    assert not window.closed
+    window.close()
+    assert window.closed
+
+
+def test_binary_window_end_too_big():
+    with pytest.raises(ValueError, match="beyond end of the file"):
+        BinaryIOWindow(io.BytesIO(b"abc"), start=0, end=4)
+
+
+def test_binary_window_start_too_small():
+    with pytest.raises(ValueError, match="before the start of the file"):
+        BinaryIOWindow(io.BytesIO(b"abc"), start=-4)
+
+
+def test_binary_window_end_before_start():
+    with pytest.raises(ValueError, match=" is before start position"):
+        BinaryIOWindow(io.BytesIO(b"abc"), start=1, end=-3)

--- a/fileformats/core/tests/test_io.py
+++ b/fileformats/core/tests/test_io.py
@@ -55,14 +55,16 @@ def test_binary_window_negative():
 
 
 def test_binary_window_readlines():
-    data = b"abc\ndef\nghi\njkl\n"
+    data = b"abc\ndef\nghi\njkl\nmn"
     with BinaryIOWindow(io.BytesIO(data), start=4, end=-4) as window:
-        assert window.readlines() == [b"def\n", b"ghi\n"]
+        assert window.readlines() == [b"def\n", b"ghi\n", b"jk"]
+        assert window.readlines(hint=8) == [b"def\n", b"ghi\n"]
         window.seek(0)
         assert next(window) == b"def\n"
         assert window.tell() == 4
         assert window.readline() == b"ghi\n"
-        assert list(window) == [b"def\n", b"ghi\n"]
+        assert window.readline() == b"jk"
+        assert list(window) == [b"def\n", b"ghi\n", b"jk"]
 
 
 def test_binary_window_write():


### PR DESCRIPTION
Adds BinaryIOWindow class so a part of a file can be presented as a file stream to be read into a 3rd party reader, e.g. trailing DICOM header appended to Siemens raw pet data files