### PR TITLE
Allow read_metadata kwargs to be passed to FileSet.__init__

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,4 +37,4 @@ repos:
             --non-interactive,
           ]
         exclude: tests
-        additional_dependencies: [pytest, attrs]
+        additional_dependencies: [pytest, attrs, imageio]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,4 +37,4 @@ repos:
             --non-interactive,
           ]
         exclude: tests
-        additional_dependencies: [pytest]
+        additional_dependencies: [pytest, attrs]

--- a/conftest.py
+++ b/conftest.py
@@ -34,11 +34,12 @@ logger.addHandler(sch)
 if os.getenv("_PYTEST_RAISE", "0") != "0":
 
     @pytest.hookimpl(tryfirst=True)
-    def pytest_exception_interact(call: ty.Any) -> None:
-        raise call.excinfo.value
+    def pytest_exception_interact(call: pytest.CallInfo[ty.Any]) -> None:
+        if call.excinfo is not None:
+            raise call.excinfo.value
 
     @pytest.hookimpl(tryfirst=True)
-    def pytest_internalerror(excinfo: ty.Any) -> None:
+    def pytest_internalerror(excinfo: pytest.ExceptionInfo[BaseException]) -> None:
         raise excinfo.value
 
 

--- a/extras/fileformats/extras/application/medical.py
+++ b/extras/fileformats/extras/application/medical.py
@@ -9,11 +9,13 @@ from fileformats.core import SampleFileGenerator
 
 @extra_implementation(FileSet.read_metadata)
 def dicom_read_metadata(
-    dicom: Dicom, selected_keys: ty.Optional[ty.Collection[str]] = None
+    dicom: Dicom,
+    specific_tags: ty.Optional[ty.Collection[str]] = None,
+    **kwargs: ty.Any,
 ) -> ty.Mapping[str, ty.Any]:
     dcm = pydicom.dcmread(
         dicom.fspath,
-        specific_tags=list(selected_keys if selected_keys is not None else []),
+        specific_tags=list(specific_tags if specific_tags is not None else []),
     )
     [getattr(dcm, a, None) for a in dir(dcm)]  # Ensure all keywords are set
     metadata = {

--- a/extras/fileformats/extras/application/serialization.py
+++ b/extras/fileformats/extras/application/serialization.py
@@ -24,7 +24,7 @@ def convert_data_serialization(
     output_path = out_dir / (
         in_file.fspath.stem + (output_format.ext if output_format.ext else "")
     )
-    return output_format.save_new(output_path, dct)
+    return output_format.new(output_path, dct)
 
 
 @extra_implementation(DataSerialization.load)

--- a/extras/fileformats/extras/image/converters.py
+++ b/extras/fileformats/extras/image/converters.py
@@ -19,10 +19,10 @@ def convert_image(
     output_format: ty.Type[RasterImage],
     out_dir: ty.Optional[Path] = None,
 ) -> RasterImage:
-    data_array = in_file.read_data()
+    data_array = in_file.load()
     if out_dir is None:
         out_dir = Path(tempfile.mkdtemp())
     output_path = out_dir / (
         in_file.fspath.stem + (output_format.ext if output_format.ext else "")
     )
-    return output_format.save_new(output_path, data_array)
+    return output_format.new(output_path, data_array)

--- a/extras/fileformats/extras/image/readwrite.py
+++ b/extras/fileformats/extras/image/readwrite.py
@@ -1,4 +1,6 @@
 import imageio
+import numpy  # noqa: F401
+import typing  # noqa: F401
 from fileformats.core import extra_implementation
 from fileformats.image.raster import RasterImage, DataArrayType
 

--- a/extras/fileformats/extras/image/readwrite.py
+++ b/extras/fileformats/extras/image/readwrite.py
@@ -3,11 +3,11 @@ from fileformats.core import extra_implementation
 from fileformats.image.raster import RasterImage, DataArrayType
 
 
-@extra_implementation(RasterImage.read_data)
+@extra_implementation(RasterImage.load)
 def read_raster_data(image: RasterImage) -> DataArrayType:
     return imageio.imread(image.fspath)  # type: ignore
 
 
-@extra_implementation(RasterImage.write_data)
-def write_raster_data(image: RasterImage, data_array: DataArrayType) -> None:
-    imageio.imwrite(image.fspath, data_array)
+@extra_implementation(RasterImage.save)
+def write_raster_data(image: RasterImage, data: DataArrayType) -> None:
+    imageio.imwrite(image.fspath, data)

--- a/fileformats/application/serialization.py
+++ b/fileformats/application/serialization.py
@@ -1,8 +1,8 @@
 import json
 import typing as ty
-from fileformats.core.typing import Self, TypeAlias
+from fileformats.core.typing import TypeAlias
 from pathlib import Path
-from fileformats.core import extra, DataType, FileSet, extra_implementation
+from fileformats.core import DataType, FileSet, extra_implementation
 from fileformats.core.mixin import WithClassifiers
 from ..generic import File
 from fileformats.core.exceptions import FormatMismatchError
@@ -43,23 +43,6 @@ class DataSerialization(WithClassifiers, File):
     binary: bool = False
 
     iana_mime: ty.Optional[str] = None
-
-    @extra
-    def load(self) -> LoadedSerialization:
-        """Load the contents of the file into a dictionary"""
-        raise NotImplementedError
-
-    @extra
-    def save(self, data: LoadedSerialization) -> None:
-        """Serialise a dictionary to a new file"""
-        raise NotImplementedError
-
-    @classmethod
-    def save_new(cls, fspath: ty.Union[str, Path], data: LoadedSerialization) -> Self:
-        # We have to use a mock object as the data file hasn't been written yet
-        mock = cls.mock(fspath)
-        mock.save(data)
-        return cls(fspath)
 
 
 class Xml(DataSerialization):

--- a/fileformats/core/extras.py
+++ b/fileformats/core/extras.py
@@ -78,7 +78,11 @@ def extra_implementation(
 
         def type_match(a: ty.Union[str, type], b: ty.Union[str, type]) -> bool:
             return (
-                a == b or inspect.isclass(a) and inspect.isclass(b) and issubclass(b, a)
+                a is ty.Any  # type: ignore[comparison-overlap]
+                or a == b
+                or inspect.isclass(a)
+                and inspect.isclass(b)
+                and issubclass(b, a)
             )
 
         mhas_kwargs = msig_args and msig_args[-1].kind == inspect.Parameter.VAR_KEYWORD

--- a/fileformats/core/extras.py
+++ b/fileformats/core/extras.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 import functools
 import urllib.error
 import fileformats.core
-from fileformats.core.typing import TypeAlias
+from fileformats.core.typing import TypeAlias, eval_type
 from .datatype import DataType
 from .converter_helpers import ConverterWrapper, ConverterSpec, SubtypeVar
 from .exceptions import FormatConversionError, FileFormatsExtrasError
@@ -33,7 +33,7 @@ def extra(method: ExtraMethod) -> "ExtraMethod":
         try:
             return dispatch_method(obj, *args, **kwargs)
         except NotImplementedError:
-            msg = f"No implementation for '{method.__name__}' extra for {cls.__name__} types"
+            msg = f"No implementation for {method.__name__!r} extra for {cls.__name__} types"
             for xtra in extras:
                 if not xtra.imported:
                     try:
@@ -72,25 +72,52 @@ def extra_implementation(
     def decorator(implementation: ExtraImplementation) -> ExtraImplementation:
         msig = inspect.signature(method)
         fsig = inspect.signature(implementation)
+        msig_args = list(msig.parameters.values())[1:]
+        fsig_args = list(fsig.parameters.values())[1:]
+        differences = []
 
         def type_match(a: ty.Union[str, type], b: ty.Union[str, type]) -> bool:
-            return isinstance(a, str) or isinstance(b, str) or a == b
-
-        differences = []
-        for i, (mparam, fparam) in enumerate(
-            zip_longest(
-                list(msig.parameters.values())[1:], list(fsig.parameters.values())[1:]
+            try:
+                a = eval_type(a)
+            except ValueError:
+                pass
+            try:
+                b = eval_type(b)
+            except ValueError:
+                pass
+            return (
+                a == b or inspect.isclass(a) and inspect.isclass(b) and issubclass(b, a)
             )
-        ):
+
+        mhas_kwargs = msig_args and msig_args[-1].kind == inspect.Parameter.VAR_KEYWORD
+        fhas_kwargs = fsig_args and fsig_args[-1].kind == inspect.Parameter.VAR_KEYWORD
+        if mhas_kwargs:
+            mkwargs = msig_args.pop()
+            if fhas_kwargs:
+                fkwargs = fsig_args.pop()
+                mkwargs_type = mkwargs.annotation
+                fkwargs_type = fkwargs.annotation
+                if not type_match(mkwargs_type, fkwargs_type):
+                    differences.append(
+                        f"Type of keyword args: {mkwargs_type!r} vs {fkwargs_type!r}"
+                    )
+            else:
+                differences.append("variable keywords vs non-variable keywords")
+        elif fhas_kwargs:
+            differences.append("non-variable keywords vs variable keywords")
+            fsig_args.pop()
+
+        for i, (mparam, fparam) in enumerate(zip_longest(msig_args, fsig_args)):
             if mparam is None:
-                differences.append(
-                    f"found additional argument, '{fparam.name}', at position {i}"
-                )
+                if not mkwargs:
+                    differences.append(
+                        f"found additional argument, {fparam.name!r}, at position {i}"
+                    )
                 continue
             if fparam is None:
                 if mparam.default is mparam.empty:
                     differences.append(
-                        f"override missing required argument '{mparam.name}'"
+                        f"override missing required argument {mparam.name!r}"
                     )
                 continue
             mname = mparam.name
@@ -99,18 +126,18 @@ def extra_implementation(
             ftype = fparam.annotation
             if mname != fname:
                 differences.append(
-                    f"name of parameter at position {i}: {mname} vs {fname}"
+                    f"name of parameter at position {i}: {mname!r} vs {fname!r}"
                 )
             elif not type_match(mtype, ftype):
-                differences.append(f"Type of '{mname}' arg: {mtype} vs {ftype}")
+                differences.append(f"Type of {mname!r} arg: {mtype!r} vs {ftype!r}")
         if not type_match(msig.return_annotation, fsig.return_annotation):
             differences.append(
-                f"return type: {msig.return_annotation} vs {fsig.return_annotation}"
+                f"return type: {msig.return_annotation!r} vs {fsig.return_annotation!r}"
             )
         if differences:
             raise TypeError(
                 f"Arguments differ between the signature of the "
-                f"decorated method {method} and the registered override {implementation}:\n"
+                f"decorated method {method} and the implementing function {implementation}:\n"
                 + "\n".join(differences)
             )
         dispatch_method.register(implementation)

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -178,6 +178,52 @@ class FileSet(DataType):
     def __repr__(self) -> str:
         return f"{self.type_name}('" + "', '".join(str(p) for p in self.fspaths) + "')"
 
+    @extra
+    def load(self) -> ty.Any:
+        """Load the contents of the file into an object of type that make sense for the
+        datat type
+
+        Returns
+        -------
+        Any
+            the data loaded from the file in an type to the format
+        """
+
+    @extra
+    def save(self, data: ty.Any) -> None:
+        """Load new contents from a format-specific object
+
+        Parameters
+        ----------
+        data: Any
+            the data to be saved to the file in a type that matches the one loaded by
+            the `load` method
+        """
+
+    @classmethod
+    def new(cls, fspath: ty.Union[str, Path], data: ty.Any) -> Self:
+        """Create a new file-set object with the given data saved to the file
+
+        Parameters
+        ----------
+        fspath: str | Path
+            the file-system path to save the data to. Additional paths should be
+            able to be inferred from this path
+        data: Any
+            the data to be saved to the file in a type that matches the one loaded by
+            the `load` method
+
+        Returns
+        -------
+        FileSet
+            a new file-set object with the given data saved to the file
+        """
+        # We have to use a mock object as the data file hasn't been written yet so can't
+        # be validated
+        mock = cls.mock(fspath)
+        mock.save(data)
+        return cls(fspath)
+
     @property
     def parent(self) -> Path:
         "A common parent directory for all the top-level paths in the file-set"

--- a/fileformats/core/mixin.py
+++ b/fileformats/core/mixin.py
@@ -186,7 +186,7 @@ class WithSeparateHeader(WithAdjacentFiles):
     def read_metadata(
         self, selected_keys: ty.Optional[ty.Collection[str]] = None
     ) -> ty.Mapping[str, ty.Any]:
-        header: ty.Dict[str, ty.Any] = self.header.load()  # type: ignore[attr-defined]
+        header: ty.Dict[str, ty.Any] = self.header.load()
         if selected_keys:
             header = {k: v for k, v in header.items() if k in selected_keys}
         return header
@@ -227,12 +227,16 @@ class WithSideCars(WithAdjacentFiles):
         metadata: ty.Dict[str, ty.Any] = dict(self.primary_type.read_metadata(self, selected_keys=selected_keys))  # type: ignore[arg-type]
         for side_car in self.side_cars:
             try:
-                side_car_metadata: ty.Dict[str, ty.Any] = side_car.load()  # type: ignore[attr-defined]
+                side_car_metadata: ty.Dict[str, ty.Any] = side_car.load()
             except AttributeError:
                 continue
-            else:
-                side_car_class_name: str = to_mime_format_name(type(side_car).__name__)
-                metadata[side_car_class_name] = side_car_metadata
+            if not isinstance(side_car_metadata, dict):
+                raise TypeError(
+                    f"`load` method of side-car type {type(side_car)} must return a "
+                    f"dictionary, not {type(side_car_metadata)!r}"
+                )
+            side_car_class_name: str = to_mime_format_name(type(side_car).__name__)
+            metadata[side_car_class_name] = side_car_metadata
         return metadata
 
     @classproperty

--- a/fileformats/core/mixin.py
+++ b/fileformats/core/mixin.py
@@ -183,12 +183,8 @@ class WithSeparateHeader(WithAdjacentFiles):
     def header(self) -> "fileformats.core.FileSet":
         return self.header_type(self.select_by_ext(self.header_type))  # type: ignore[attr-defined]
 
-    def read_metadata(
-        self, selected_keys: ty.Optional[ty.Collection[str]] = None
-    ) -> ty.Mapping[str, ty.Any]:
+    def read_metadata(self, **kwargs: ty.Any) -> ty.Mapping[str, ty.Any]:
         header: ty.Dict[str, ty.Any] = self.header.load()
-        if selected_keys:
-            header = {k: v for k, v in header.items() if k in selected_keys}
         return header
 
 
@@ -221,10 +217,8 @@ class WithSideCars(WithAdjacentFiles):
     def side_cars(self) -> ty.Tuple["fileformats.core.FileSet", ...]:
         return tuple(tp(self.select_by_ext(tp)) for tp in self.side_car_types)  # type: ignore[attr-defined]
 
-    def read_metadata(
-        self, selected_keys: ty.Optional[ty.Collection[str]] = None
-    ) -> ty.Mapping[str, ty.Any]:
-        metadata: ty.Dict[str, ty.Any] = dict(self.primary_type.read_metadata(self, selected_keys=selected_keys))  # type: ignore[arg-type]
+    def read_metadata(self, **kwargs: ty.Any) -> ty.Mapping[str, ty.Any]:
+        metadata: ty.Dict[str, ty.Any] = dict(self.primary_type.read_metadata(self, **kwargs))  # type: ignore[arg-type]
         for side_car in self.side_cars:
             try:
                 side_car_metadata: ty.Dict[str, ty.Any] = side_car.load()

--- a/fileformats/core/tests/test_general.py
+++ b/fileformats/core/tests/test_general.py
@@ -132,9 +132,7 @@ class ImageWithInlineHeader(File):
 
     header_separator = b"---END HEADER---"
 
-    def read_metadata(
-        self, selected_keys: ty.Optional[ty.Collection[str]] = None
-    ) -> ty.Mapping[str, ty.Any]:
+    def read_metadata(self, **kwargs: ty.Any) -> ty.Mapping[str, ty.Any]:
         hdr = self.contents.split(self.header_separator)[0].decode("utf-8")
         return {k: int(v) for k, v in (ln.split(":") for ln in hdr.splitlines())}
 

--- a/fileformats/core/tests/test_general.py
+++ b/fileformats/core/tests/test_general.py
@@ -13,8 +13,6 @@ def test_init_args(work_dir):
     fspath = work_dir / "test.txt"
     write_test_file(fspath)
     File([fspath])
-    with pytest.raises(TypeError):
-        File(fspath, fspath)
 
 
 class TestFile(File):

--- a/fileformats/core/tests/test_metadata.py
+++ b/fileformats/core/tests/test_metadata.py
@@ -11,11 +11,15 @@ class FileWithMetadata(File):
 
 @extra_implementation(FileSet.read_metadata)
 def aformat_read_metadata(
-    mf: FileWithMetadata, **kwargs: ty.Any
+    mf: FileWithMetadata,
+    selected_keys: ty.Optional[ty.Collection[str]] = None,
+    **kwargs: ty.Any,
 ) -> ty.Mapping[str, ty.Any]:
     with open(mf) as f:
         metadata = f.read()
     dct = dict(ln.split(":") for ln in metadata.splitlines())
+    if selected_keys:
+        dct = {k: v for k, v in dct.items() if k in selected_keys}
     return dct
 
 
@@ -42,7 +46,7 @@ def test_metadata(file_with_metadata_fspath):
 
 def test_select_metadata(file_with_metadata_fspath):
     file_with_metadata = FileWithMetadata(
-        file_with_metadata_fspath, metadata_keys=["a", "b", "c"]
+        file_with_metadata_fspath, selected_keys=["a", "b", "c"]
     )
     assert file_with_metadata.metadata["a"] == "1"
     assert sorted(file_with_metadata.metadata) == ["a", "b", "c"]

--- a/fileformats/core/tests/test_metadata.py
+++ b/fileformats/core/tests/test_metadata.py
@@ -11,13 +11,11 @@ class FileWithMetadata(File):
 
 @extra_implementation(FileSet.read_metadata)
 def aformat_read_metadata(
-    mf: FileWithMetadata, selected_keys: ty.Optional[ty.Collection[str]] = None
+    mf: FileWithMetadata, **kwargs: ty.Any
 ) -> ty.Mapping[str, ty.Any]:
     with open(mf) as f:
         metadata = f.read()
     dct = dict(ln.split(":") for ln in metadata.splitlines())
-    if selected_keys:
-        dct = {k: v for k, v in dct.items() if k in selected_keys}
     return dct
 
 

--- a/fileformats/core/tests/test_mixin.py
+++ b/fileformats/core/tests/test_mixin.py
@@ -107,9 +107,7 @@ class ImageWithInlineHeader(File):
 
     header_separator = b"---END HEADER---"
 
-    def read_metadata(
-        self, selected_keys: ty.Optional[ty.Collection[str]] = None
-    ) -> ty.Mapping[str, ty.Any]:
+    def read_metadata(self, **kwargs: ty.Any) -> ty.Mapping[str, ty.Any]:
         hdr = self.contents.split(self.header_separator)[0].decode("utf-8")
         return dict(ln.split(":") for ln in hdr.splitlines())
 

--- a/fileformats/core/typing.py
+++ b/fileformats/core/typing.py
@@ -1,5 +1,7 @@
-import typing as ty
 import sys
+import re
+import typing as ty
+from importlib import import_module
 from pathlib import Path
 
 if sys.version_info[:2] < (3, 11):
@@ -22,10 +24,25 @@ FspathsInputType: TypeAlias = ty.Union[  # noqa: F821
 PathType: TypeAlias = ty.Union[str, Path]
 
 
+def eval_type(type_str: ty.Union[str, type]) -> type:
+    """Evaluates a type string so it can be compared with the type it represents"""
+    if not isinstance(type_str, str):
+        return type_str
+    module_match = re.match(r"((?:\w+\.)*).*", type_str)
+    if module_match:
+        mod_path = module_match.group(1)[:-1]
+        import_module(mod_path)
+    try:
+        return eval(type_str)  # type: ignore[no-any-return]
+    except Exception:
+        raise ValueError(f"Could not evaluate '{type_str}' type")
+
+
 __all__ = [
     "CryptoMethod",
     "FspathsInputType",
     "PathType",
     "TypeAlias",
     "Self",
+    "eval_type",
 ]

--- a/fileformats/core/typing.py
+++ b/fileformats/core/typing.py
@@ -1,7 +1,5 @@
 import sys
-import re
 import typing as ty
-from importlib import import_module
 from pathlib import Path
 
 if sys.version_info[:2] < (3, 11):
@@ -24,25 +22,10 @@ FspathsInputType: TypeAlias = ty.Union[  # noqa: F821
 PathType: TypeAlias = ty.Union[str, Path]
 
 
-def eval_type(type_str: ty.Union[str, type]) -> type:
-    """Evaluates a type string so it can be compared with the type it represents"""
-    if not isinstance(type_str, str):
-        return type_str
-    module_match = re.match(r"((?:\w+\.)*).*", type_str)
-    if module_match:
-        mod_path = module_match.group(1)[:-1]
-        import_module(mod_path)
-    try:
-        return eval(type_str)  # type: ignore[no-any-return]
-    except Exception:
-        raise ValueError(f"Could not evaluate '{type_str}' type")
-
-
 __all__ = [
     "CryptoMethod",
     "FspathsInputType",
     "PathType",
     "TypeAlias",
     "Self",
-    "eval_type",
 ]

--- a/fileformats/generic/directory.py
+++ b/fileformats/generic/directory.py
@@ -1,7 +1,7 @@
 import typing as ty
 from pathlib import Path
 from fileformats.core.exceptions import FormatMismatchError
-from fileformats.core.decorators import classproperty
+from fileformats.core.decorators import classproperty, mtime_cached_property
 from .fsobject import FsObject
 from fileformats.core.fileset import FileSet, FILE_CHUNK_LEN_DEFAULT
 from fileformats.core.mixin import WithClassifiers
@@ -44,15 +44,17 @@ class Directory(FsObject):
             )
         return fspath
 
-    @property
-    def contents(self) -> ty.Iterable[FileSet]:
+    @mtime_cached_property
+    def contents(self) -> ty.List[FileSet]:
+        contnts = []
         for content_type in self.content_types:
             assert content_type
             for p in self.fspath.iterdir():
                 try:
-                    yield content_type([p])
+                    contnts.append(content_type([p], **self._metadata_kwargs))
                 except FormatMismatchError:
                     continue
+        return contnts
 
     @classproperty
     def unconstrained(cls) -> bool:

--- a/fileformats/generic/set.py
+++ b/fileformats/generic/set.py
@@ -1,9 +1,9 @@
 import typing as ty
 from fileformats.core.fileset import FileSet
+from functools import cached_property
 from fileformats.core.exceptions import (
     FormatMismatchError,
 )
-from fileformats.core.decorators import mtime_cached_property
 from fileformats.core.mixin import WithClassifiers
 
 
@@ -13,14 +13,16 @@ class TypedSet(FileSet):
 
     content_types: ty.Tuple[ty.Type[FileSet], ...] = ()
 
-    @mtime_cached_property
-    def contents(self) -> ty.Iterable[FileSet]:
+    @cached_property
+    def contents(self) -> ty.List[FileSet]:
+        contnts = []
         for content_type in self.content_types:
             for p in self.fspaths:
                 try:
-                    yield content_type([p])
+                    contnts.append(content_type([p], **self._metadata_kwargs))
                 except FormatMismatchError:
                     continue
+        return contnts
 
     @property
     def _validate_contents(self) -> None:

--- a/fileformats/image/raster.py
+++ b/fileformats/image/raster.py
@@ -9,7 +9,7 @@ if ty.TYPE_CHECKING:
     import numpy.typing  # noqa: F401
 
 
-DataArrayType: TypeAlias = "numpy.typing.NDArray[ty.Union[numpy.floating[typing.Any], numpy.integer[typing.Any]]]"
+DataArrayType: TypeAlias = "numpy.typing.NDArray[typing.Union[numpy.floating[typing.Any], numpy.integer[typing.Any]]]"
 
 
 class RasterImage(Image):

--- a/fileformats/image/raster.py
+++ b/fileformats/image/raster.py
@@ -9,7 +9,9 @@ if ty.TYPE_CHECKING:
     import numpy.typing  # noqa: F401
 
 
-DataArrayType: TypeAlias = "numpy.typing.NDArray[typing.Union[numpy.floating[typing.Any], numpy.integer[typing.Any]]]"
+DataArrayType: TypeAlias = (
+    ty.Any
+)  # In Python < 3.9 this is probmematic "numpy.typing.NDArray[typing.Union[numpy.floating[typing.Any], numpy.integer[typing.Any]]]"
 
 
 class RasterImage(Image):

--- a/fileformats/image/raster.py
+++ b/fileformats/image/raster.py
@@ -1,8 +1,6 @@
-from pathlib import Path
-from fileformats.core.typing import Self, TypeAlias
+from fileformats.core.typing import TypeAlias
 import typing as ty
 from fileformats.core.mixin import WithMagicNumber
-from fileformats.core import extra
 from fileformats.core.exceptions import FormatMismatchError
 from .base import Image
 
@@ -20,21 +18,6 @@ class RasterImage(Image):
     # iana_mime = None
     pass
     binary = True
-
-    @extra
-    def read_data(self) -> DataArrayType:
-        ...
-
-    @extra
-    def write_data(self, data_array: DataArrayType) -> None:
-        ...
-
-    @classmethod
-    def save_new(cls, fspath: Path, data_array: DataArrayType) -> Self:
-        # We have to use a mock object as the data file hasn't been written yet
-        mock = cls.mock(fspath)
-        mock.write_data(data_array)
-        return cls(fspath)
 
 
 class Bitmap(WithMagicNumber, RasterImage):

--- a/fileformats/image/raster.py
+++ b/fileformats/image/raster.py
@@ -1,17 +1,15 @@
 from fileformats.core.typing import TypeAlias
+import typing  # noqa: F401
 import typing as ty
 from fileformats.core.mixin import WithMagicNumber
 from fileformats.core.exceptions import FormatMismatchError
 from .base import Image
 
-# if ty.TYPE_CHECKING:
-#     import numpy.typing
-#     import numpy as np
+if ty.TYPE_CHECKING:
+    import numpy.typing  # noqa: F401
 
 
-DataArrayType: TypeAlias = (
-    ty.Any
-)  # "numpy.typing.NDArray[ty.Union[np.floating, np.integer]]"
+DataArrayType: TypeAlias = "numpy.typing.NDArray[ty.Union[numpy.floating[typing.Any], numpy.integer[typing.Any]]]"
 
 
 class RasterImage(Image):

--- a/scripts/import_all.py
+++ b/scripts/import_all.py
@@ -1,0 +1,3 @@
+from fileformats.core import FileSet
+
+list(FileSet.all_formats)


### PR DESCRIPTION
Changes the signature of FileSet.__init__ to:
* allow var kwargs, which will be interpreted as kwargs to be passed to `read_metadata` implementations
    * Note, `metadata` is the only reserved keyword, which can take explicit metadata
* fspaths are now varargs so `SetOf[Png]('/path/to/one/png.png', '/path/to/another/png.png')` is now valid

`load`, `save` extras hooks and the `new` method (which uses `save` to create a new fileformat object) have been moved to base FileSet class.