### PR TITLE
Remote direct references in pyproject.tomls

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,6 +46,8 @@ jobs:
       run: python3 -m pip install -e .[test]
     - name: Install Extras Package
       run: python3 -m pip install -e ./extras[test]
+    - name: Install development Pydra
+      run: pip install --no-deps git+https://github.com/nipype/pydra.git@new-syntax
     - name: MyPy
       run: mypy --install-types --non-interactive --no-warn-unused-ignores .
     - name: Pytest

--- a/extras/pyproject.toml
+++ b/extras/pyproject.toml
@@ -43,7 +43,6 @@ test = [
     "pytest-cov>=2.12.1",
     "codecov",
     "medimages4tests",
-    "pydra @ git+https://github.com/nipype/pydra.git@new-syntax",
 ]
 
 [project.urls]
@@ -60,7 +59,7 @@ version-file = "fileformats/extras/core/_version.py"
 packages = ["fileformats"]
 
 [tool.hatch.metadata]
-allow-direct-references = true
+allow-direct-references = false
 
 [tool.black]
 target-version = ['py38']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ source = "vcs"
 version-file = "fileformats/core/_version.py"
 
 [tool.hatch.metadata]
-allow-direct-references = true
+allow-direct-references = false
 
 [tool.hatch.build]
 packages = ["fileformats"]


### PR DESCRIPTION
set up install and ci-cd to not use direct references in pyproject.tomls