### PR TITLE
reworked copy/move methods to include "avoid_clashes" feature

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,4 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 env =
     TEST_AWS_BUCKET=ais-s3-ops-healthcheck-s3bucket-1hd8l4tsfl8hx
+addopts = -vv


### PR DESCRIPTION
Added ability to specify and 'avoid_clashes' arg to copy and move methods to add an incrementing counter (e.g. 'file.txt' -> 'file (1).txt') to filenames