### PR TITLE
modified FileSet.convertible_from so it only returns concrete classes, not abstract base classes

### DIFF
--- a/extras/fileformats/extras/core/tests/test_converter.py
+++ b/extras/fileformats/extras/core/tests/test_converter.py
@@ -3,8 +3,9 @@ import attrs
 from pathlib import Path
 import pytest
 from pydra.compose import python, shell
-from fileformats.generic import File
+from fileformats.generic import File, FileSet
 from fileformats.testing import Foo, Bar, Baz, Qux
+from fileformats.testing import ConvertibleToFile, ConcreteClass, AnotherConcreteClass
 from fileformats.core import converter
 from fileformats.core.exceptions import FormatConversionError
 from conftest import write_test_file
@@ -91,9 +92,18 @@ def test_convert_mapped_conversion(work_dir):
     assert bar.raw_contents == baz.raw_contents
 
 
-def test_convertible_from():
-
-    assert Bar.convertible_from() == ty.Union[Bar, Foo, Baz]
-    assert Qux.convertible_from() == ty.Union[Qux, Foo]
-    assert Foo.convertible_from() == Foo
-    assert Baz.convertible_from() == Baz
+@pytest.mark.parametrize(
+    ["klass", "convertible_from"],
+    [
+        [Bar, ty.Union[Bar, Baz, Foo]],
+        [Qux, ty.Union[Foo, Qux]],
+        [Foo, Foo],
+        [Baz, Baz],
+        [
+            ConvertibleToFile,
+            ty.Union[AnotherConcreteClass, ConcreteClass, ConvertibleToFile],
+        ],
+    ],
+)
+def test_convertible_from(klass: type[FileSet], convertible_from: type[FileSet]):
+    assert klass.convertible_from() == convertible_from

--- a/extras/fileformats/extras/testing/__init__.py
+++ b/extras/fileformats/extras/testing/__init__.py
@@ -1,0 +1,9 @@
+from fileformats.core import converter
+from fileformats.testing import AbstractFile, ConvertibleToFile
+from pydra.compose import python
+
+
+@converter
+@python.define(outputs={"out_file": ConvertibleToFile})  # type: ignore[misc]
+def ConvertibleToConverter(in_file: AbstractFile):
+    return ConvertibleToFile.sample()

--- a/extras/fileformats/extras/testing/__init__.py
+++ b/extras/fileformats/extras/testing/__init__.py
@@ -3,7 +3,7 @@ from fileformats.testing import AbstractFile, ConvertibleToFile
 from pydra.compose import python
 
 
-@converter
-@python.define(outputs={"out_file": ConvertibleToFile})  # type: ignore[misc]
-def ConvertibleToConverter(in_file: AbstractFile):
+@converter  # pyright: ignore[reportArgumentType]
+@python.define(outputs=["out_file"])  # type: ignore[misc]
+def ConvertibleToConverter(in_file: AbstractFile) -> ConvertibleToFile:
     return ConvertibleToFile.sample()

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -1589,7 +1589,7 @@ class FileSet(DataType):
         else:
             logger.debug('Using full copy for the "copy" operation')
             assert selected_mode & self.CopyMode.copy
-            copy_dir = shutil.copytree
+            copy_dir = shutil.copytree  # type: ignore
             copy_file = shutil.copyfile  # type: ignore
 
         # Prepare destination directory

--- a/fileformats/core/fileset.py
+++ b/fileformats/core/fileset.py
@@ -630,11 +630,13 @@ class FileSet(DataType):
         return converters_dict
 
     @classmethod
-    def convertible_from(cls) -> ty.Type[DataType]:
+    def convertible_from(cls) -> ty.Type["DataType"]:
         """Union of types that can be converted to this type, including the current type.
         If there are no other types that can be converted to this type, return the current type
         """
-        datatypes = (cls,) + tuple(cls.get_converters_dict().keys())
+        datatypes: ty.Tuple[ty.Type[DataType], ...] = (cls,) + tuple(
+            cls.get_converters_dict().keys()
+        )
         if len(datatypes) == 1:
             return cls
         concrete_datatypes = set()
@@ -645,13 +647,15 @@ class FileSet(DataType):
             if isinstance(subclass, type) and issubclass(subclass, FileSet)
         ]
 
-        def subclasses(klass) -> ty.Generator[type[FileSet], None, None]:
+        def subclasses(
+            klass: ty.Type[DataType],
+        ) -> ty.Generator[ty.Type[DataType], None, None]:
             """Yields all non-abstract subclasses of the given class."""
             for subclass in sisters:
                 if issubclass(subclass, klass) and subclass is not klass:
                     yield subclass
 
-        def add_concrete(datatype):
+        def add_concrete(datatype: ty.Type[DataType]) -> None:
             """Adds datatype to concrete_datatypes list if not abstract, otherwise adds all non-abstract subclasses"""
             if inspect.isabstract(datatype):
                 for subclass in subclasses(datatype):
@@ -662,7 +666,9 @@ class FileSet(DataType):
         # Create list of non-abstract datatypes
         for datatype in datatypes:
             add_concrete(datatype)
-        return ty.Union.__getitem__(tuple(sorted(concrete_datatypes, key=lambda x: x.__name__)))  # type: ignore[return-value]
+        return ty.Union.__getitem__(  # pyright: ignore[reportAttributeAccessIssue]
+            tuple(sorted(concrete_datatypes, key=lambda x: x.__name__))
+        )  # type: ignore[return-value]
 
     @classmethod
     def get_converter_defs(cls, source_format: type) -> ty.List["Converter"]:

--- a/fileformats/testing/__init__.py
+++ b/fileformats/testing/__init__.py
@@ -20,6 +20,13 @@ from .headers import (
 from .classifiers.file import A, B, C, D, E, F, G, H, J, K, L, M, N, P, Q, R, TestField
 from .classifiers.generic import Classified, U, V, W, X, Y, Z
 from .magic import Magic, MagicVersion
+from .abstract import (
+    AbstractFile,
+    AbstractSubclass,
+    ConcreteClass,
+    AnotherConcreteClass,
+    ConvertibleToFile,
+)
 
 __all__ = [
     "__version__",
@@ -68,4 +75,9 @@ __all__ = [
     "Z",
     "Magic",
     "MagicVersion",
+    "AbstractFile",
+    "AbstractSubclass",
+    "ConcreteClass",
+    "AnotherConcreteClass",
+    "ConvertibleToFile",
 ]

--- a/fileformats/testing/abstract.py
+++ b/fileformats/testing/abstract.py
@@ -1,0 +1,38 @@
+import typing as ty
+from abc import abstractproperty
+from pathlib import Path
+from fileformats.generic import File
+from fileformats.core import converter
+
+
+class AbstractFile(File):
+    """Base class for all medical imaging data including pre-image raw data and
+    associated data"""
+
+    @abstractproperty
+    def a_property(self):
+        raise NotImplementedError
+
+
+class AbstractSubclass(AbstractFile):
+    pass
+
+
+class ConcreteClass(AbstractFile):
+
+    @property
+    def a_property(self):
+        return "Concrete implementation of a_property"
+
+
+class AnotherConcreteClass(AbstractSubclass):
+
+    @property
+    def a_property(self):
+        return "Another concrete implementation of a_property"
+
+
+class ConvertibleToFile(File):
+    """A class that can be converted from a file"""
+
+    pass

--- a/fileformats/testing/abstract.py
+++ b/fileformats/testing/abstract.py
@@ -1,8 +1,5 @@
-import typing as ty
 from abc import abstractproperty
-from pathlib import Path
 from fileformats.generic import File
-from fileformats.core import converter
 
 
 class AbstractFile(File):
@@ -10,7 +7,7 @@ class AbstractFile(File):
     associated data"""
 
     @abstractproperty
-    def a_property(self):
+    def a_property(self) -> str:
         raise NotImplementedError
 
 
@@ -19,16 +16,14 @@ class AbstractSubclass(AbstractFile):
 
 
 class ConcreteClass(AbstractFile):
-
     @property
-    def a_property(self):
+    def a_property(self) -> str:
         return "Concrete implementation of a_property"
 
 
 class AnotherConcreteClass(AbstractSubclass):
-
     @property
-    def a_property(self):
+    def a_property(self) -> str:
         return "Another concrete implementation of a_property"
 
 


### PR DESCRIPTION
Modified the FileSet.convertible_from classmethod so it only returns unions of concrete classes, not abstract base classes.