### PR TITLE
added collate_metadata_series utility

### DIFF
--- a/fileformats/core/tests/test_utils.py
+++ b/fileformats/core/tests/test_utils.py
@@ -1,15 +1,18 @@
-from pathlib import Path
 import os.path
 import random
 import shutil
 import time
 import typing as ty
+from pathlib import Path
+
 import pytest
-from fileformats.core import FileSet, validated_property
-from fileformats.generic import File, BinaryFile, Directory, FsObject
-from fileformats.core.mixin import WithSeparateHeader
-from fileformats.core.exceptions import UnsatisfiableCopyModeError
+
 from conftest import write_test_file
+from fileformats.core import FileSet, validated_property
+from fileformats.core.exceptions import UnsatisfiableCopyModeError
+from fileformats.core.mixin import WithSeparateHeader
+from fileformats.core.utils import collate_metadata_series
+from fileformats.generic import BinaryFile, Directory, File, FsObject
 
 
 class Mario(BinaryFile):
@@ -523,3 +526,23 @@ def test_hash_files(fsobject: FsObject, work_dir: Path, dest_dir: Path):
     )
     cpy = fsobject.copy(dest_dir)
     assert cpy.hash_files() == fsobject.hash_files()
+
+
+def test_metadata_collation1():
+    metadata_series = [
+        {"a": 1, "b": 2},
+        {"a": 1, "b": 3},
+        {"a": 1, "b": 2},
+    ]
+    collated = collate_metadata_series(metadata_series)
+    assert collated == {"a": 1, "b": [2, 3, 2]}
+
+
+def test_metadata_collation2():
+    metadata_series = [
+        {"a": 1, "b": 2, "c": "foo"},
+        {"a": 1, "b": 2, "c": "foo"},
+        {"a": 1, "b": 3, "c": "foo"},
+    ]
+    collated = collate_metadata_series(metadata_series)
+    assert collated == {"a": 1, "b": [2, 2, 3], "c": "foo"}

--- a/fileformats/core/utils.py
+++ b/fileformats/core/utils.py
@@ -9,6 +9,7 @@ import types
 import typing as ty
 import urllib.error
 import urllib.request
+from collections import Counter
 from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType
@@ -378,3 +379,50 @@ def is_union(type_: type, args: ty.Optional[ty.List[type]] = None) -> bool:
             return list(ty.get_args(type_)) == args
         return True
     return False
+
+
+def collate_metadata_series(
+    metadata_series: list[ty.Mapping[str, ty.Any]],
+) -> ty.Mapping[str, ty.Any]:
+    """Collates metadata across a series, returning a dictionary where each key is a
+    metadata field and the value is either a single value (if the field is the same
+    across all items in the series) or a list of values (if the field varies across
+    items in the series). This can be used to identify which fields are consistent
+    across the series and which fields vary, which can be useful for selecting
+    appropriate metadata fields for deidentification.
+
+    Parameters
+    ----------
+    metadata_series : list[dict[str, Any]]
+        A list of metadata dictionaries to collate
+
+    Returns
+    -------
+    dict[str, Any]
+        A dictionary where each key is a metadata field and the value is either a single
+        value (if the field is the same across all items in the series) or a list of
+        values (if the field varies across items in the series)
+    """
+    collated: dict[str, ty.Any] = {}
+    key_repeats: ty.Counter[str] = Counter()
+    varying_keys = set()
+    for metadata in metadata_series:
+        for key, val in metadata.items():
+            try:
+                prev_val = collated[key]
+            except KeyError:
+                collated[key] = (
+                    val  # Insert initial value (should only happen on first iter)
+                )
+                key_repeats.update([key])
+            else:
+                if key in varying_keys:
+                    collated[key].append(val)
+                # Check whether the value is the same as the values in the previous
+                # images in the series
+                elif val != prev_val:
+                    collated[key] = [prev_val] * key_repeats[key] + [val]
+                    varying_keys.add(key)
+                else:
+                    key_repeats.update([key])
+    return collated


### PR DESCRIPTION
added utility (from fileformats-medimage) for collating series of metadata dicts so it can be used across different extension packages and formats