### PR TITLE
fixes dicom serialization of sequences

### DIFF
--- a/extras/fileformats/extras/application/tests/test_application_medical.py
+++ b/extras/fileformats/extras/application/tests/test_application_medical.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from fileformats.application import Dicom
 
@@ -7,6 +9,30 @@ def test_dicom_metadata():
     dicom = Dicom.sample()
 
     assert dicom.metadata["EchoTime"] == 2.07
+
+
+def test_dicom_metadata_sequence_converted_to_list_of_dicts():
+    """SQ-VR elements (e.g. ReferencedImageSequence) hold a list of nested Datasets.
+    These should be converted to plain lists of dicts, like nested single Datasets
+    are, rather than left as unconverted pydicom Sequence/Dataset objects.
+    """
+    dicom = Dicom.sample()
+
+    sequence = dicom.metadata["ReferencedImageSequence"]
+    assert isinstance(sequence, list)
+    assert sequence  # sample data actually has entries to convert
+    for item in sequence:
+        assert isinstance(item, dict)
+        assert isinstance(item["ReferencedSOPInstanceUID"], str)
+
+
+def test_dicom_metadata_is_json_serialisable():
+    """The whole metadata dict, including nested sequences, should round-trip
+    through JSON (modulo values like PersonName that are deliberately kept as
+    richer objects and need `default=str` from the caller)."""
+    dicom = Dicom.sample()
+
+    json.dumps(dict(dicom.metadata), default=str)
 
 
 def test_dicom_metadata_with_specific_tags():

--- a/fileformats/application/medical.py
+++ b/fileformats/application/medical.py
@@ -38,6 +38,7 @@ class Dicom(WithMagicNumber, BinaryFile):
         import pydicom.dataelem
         import pydicom.dataset
         import pydicom.multival
+        import pydicom.sequence
         import pydicom.uid
         import pydicom.valuerep
 
@@ -52,7 +53,12 @@ class Dicom(WithMagicNumber, BinaryFile):
                 key = elem.tag.json_key  # type: ignore[attr-defined]
             if key not in omit:
                 value = elem.value  # type: ignore[attr-defined]
-                if isinstance(value, pydicom.multival.MultiValue):
+                # Sequence (SQ) elements hold a list of nested Datasets. Checked before
+                # MultiValue since in some pydicom versions Sequence subclasses it, and
+                # we want the per-item dict conversion below rather than the str() one.
+                if isinstance(value, pydicom.sequence.Sequence):
+                    value = [cls.pydicom_to_dict(item, omit) for item in value]
+                elif isinstance(value, pydicom.multival.MultiValue):
                     value = [str(v).rstrip() for v in value]
                 elif isinstance(value, pydicom.uid.UID):
                     value = str(value)


### PR DESCRIPTION
Adds support for sequences to the pydicom_to_dict function so DICOM headers with sequences can be serialised 